### PR TITLE
Terraform: avoid using default security-group for scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ example: *tfplan*
 # Ignore CLI configuration files
 .terraformrc
 terraform.rc
+
+.terraform.lock.hcl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Terraform
 
 - Add missing CopySnapshot permissions to allow AMI scanning
+- Create a dedicated security-group for scanner instead of relying on the VPC default one.
 
 ### CloudFormation
 

--- a/examples/custom_vpc/main.tf
+++ b/examples/custom_vpc/main.tf
@@ -37,5 +37,6 @@ module "instance" {
 
   user_data            = module.user_data.install_sh
   iam_instance_profile = module.agentless_scanner_role.profile.name
+  vpc_id               = var.vpc_id
   subnet_id            = var.subnet_id
 }

--- a/examples/custom_vpc/variables.tf
+++ b/examples/custom_vpc/variables.tf
@@ -3,6 +3,11 @@ variable "api_key" {
   type        = string
 }
 
+variable "vpc_id" {
+  description = "The VPC ID to launch in"
+  type        = string
+}
+
 variable "subnet_id" {
   description = "The VPC Subnet ID to launch in"
   type        = string

--- a/main.tf
+++ b/main.tf
@@ -16,6 +16,7 @@ module "instance" {
   source               = "./modules/instance"
   user_data            = module.user_data.install_sh
   iam_instance_profile = var.instance_profile_name
+  vpc_id               = module.vpc.vpc.id
   subnet_id            = module.vpc.private_subnet.id
   tags                 = var.tags
 }

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -22,6 +22,7 @@ No modules.
 |------|------|
 | [aws_autoscaling_group.asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
 | [aws_launch_template.launch_template](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_security_group.default_scanner_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 
 ## Inputs
 
@@ -38,6 +39,7 @@ No modules.
 | <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC Subnet ID to launch in | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the instance/volume created | `map(string)` | `{}` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance | `string` | `null` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to launch in | `string` | n/a | yes |
 | <a name="input_vpc_security_group_ids"></a> [vpc\_security\_group\_ids](#input\_vpc\_security\_group\_ids) | A list of security group IDs to associate with | `list(string)` | `null` | no |
 
 ## Outputs

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -28,6 +28,11 @@ variable "user_data" {
   default     = null
 }
 
+variable "vpc_id" {
+  description = "The VPC ID to launch in"
+  type        = string
+}
+
 variable "subnet_id" {
   description = "The VPC Subnet ID to launch in"
   type        = string


### PR DESCRIPTION
TF: enforce the creation of a dedicated security-group for the scanner instead of relying on the VPC default one. This required adding a new parameter to the `instance` module to pass the VPC: `vpc_id`.
