### PR TITLE
Restrict scanner role trust policy to instance with the scanner tags

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -437,6 +437,9 @@ Resources:
             Effect: Allow
             Principal:
               Service: ec2.amazonaws.com
+            Condition:
+                StringEquals:
+                  'aws:ResourceTag/DatadogAgentlessScanner': 'true'
       MaxSessionDuration: 3600
       ManagedPolicyArns:
         - !Ref 'ScannerAgentPolicy'

--- a/modules/agentless-scanner-role/main.tf
+++ b/modules/agentless-scanner-role/main.tf
@@ -16,6 +16,13 @@ data "aws_iam_policy_document" "assume_role_policy" {
       type        = "Service"
       identifiers = ["ec2.${data.aws_partition.current.dns_suffix}"]
     }
+
+    // Enforce that the role can only be assumed by an instance with the right tags.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/DatadogAgentlessScanner"
+      values   = ["true"]
+    }
   }
 }
 


### PR DESCRIPTION
Tighten the `DatadogAgentlessScannerAgentRole` by adding a condition on its trust relationship. 
This condition would prevent an attacker with only the `iam:PassRole` and `ec2:RunInstances` permissions (and not `ec2:CreateTags`) to abuse the highly privileged role that is DatadogAgentlessScannerAgentRole.