### PR TITLE
Add subnets per AZ

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -16,7 +16,9 @@ module "instance" {
   source               = "./modules/instance"
   user_data            = module.user_data.install_sh
   vpc_id               = module.vpc.vpc.id
-  subnet_id            = module.vpc.private_subnet.id
+  subnet_ids           = [for s in module.vpc.private_subnets : s.id]
   iam_instance_profile = var.instance_profile_name
   tags                 = var.tags
+
+  depends_on = [module.vpc.routing_ready]
 }

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -36,7 +36,7 @@ No modules.
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
 | <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix to be used on EC2 instance created | `string` | `"DatadogAgentlessScanner"` | no |
-| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | The VPC Subnet ID to launch in | `string` | n/a | yes |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The VPC Subnet IDs to launch in | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the instance/volume created | `map(string)` | `{}` | no |
 | <a name="input_user_data"></a> [user\_data](#input\_user\_data) | The user data to provide when launching the instance | `string` | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID to launch in | `string` | n/a | yes |

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -83,7 +83,7 @@ resource "aws_autoscaling_group" "asg" {
   #   - https://github.com/hashicorp/terraform-provider-aws/pull/32914
   ignore_failed_scaling_activities = true
 
-  vpc_zone_identifier = [var.subnet_id]
+  vpc_zone_identifier = var.subnet_ids
 
   launch_template {
     id      = aws_launch_template.launch_template.id

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -33,9 +33,9 @@ variable "vpc_id" {
   type        = string
 }
 
-variable "subnet_id" {
-  description = "The VPC Subnet ID to launch in"
-  type        = string
+variable "subnet_ids" {
+  description = "The VPC Subnet IDs to launch in"
+  type        = list(string)
 }
 
 variable "vpc_security_group_ids" {

--- a/modules/vpc/README.md
+++ b/modules/vpc/README.md
@@ -37,6 +37,7 @@ No modules.
 | [aws_vpc_endpoint.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_vpc_endpoint_service.ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 | [aws_vpc_endpoint_service.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
 | [aws_vpc_endpoint_service.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint_service) | data source |
@@ -56,7 +57,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_nap_public_id"></a> [nap\_public\_id](#output\_nap\_public\_id) | The public IP associated with the VPC's NAT |
-| <a name="output_private_subnet"></a> [private\_subnet](#output\_private\_subnet) | The private subnet of the created VPC |
-| <a name="output_public_subnet"></a> [public\_subnet](#output\_public\_subnet) | The public subnet of the created VPC |
+| <a name="output_private_subnets"></a> [private\_subnets](#output\_private\_subnets) | The private subnets of the created VPC |
+| <a name="output_public_subnets"></a> [public\_subnets](#output\_public\_subnets) | The public subnets of the created VPC |
+| <a name="output_routing_ready"></a> [routing\_ready](#output\_routing\_ready) | Allows to depends on completion of routing resources |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | The VPC created for the Datadog agentless scanner |
 <!-- END_TF_DOCS -->

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -1,10 +1,21 @@
+data "aws_availability_zones" "available" {}
+
 locals {
   dd_tags = {
     Datadog                 = "true"
     DatadogAgentlessScanner = "true"
   }
-  public_cidr               = cidrsubnet(var.cidr, 3, 0)
-  private_cidr              = cidrsubnet(var.cidr, 3, 4)
+
+  max_azs             = 3 # Limit to a maximum of 3 AZs on that region
+  private_cidr_offset = 3
+  azs_cidrs = {
+    for idx, az in slice(data.aws_availability_zones.available.names, 0, local.max_azs) :
+    az => {
+      public_cidr  = cidrsubnet("10.0.0.0/16", 3, idx),
+      private_cidr = cidrsubnet("10.0.0.0/16", 3, idx + local.private_cidr_offset)
+    }
+  }
+
   ssm_vpc_endpoint_services = ["ec2messages", "ssmmessages", "ssm"]
 }
 
@@ -23,10 +34,12 @@ resource "aws_internet_gateway" "internet_gateway" {
 }
 
 resource "aws_subnet" "public" {
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = local.public_cidr
+  for_each = local.azs_cidrs
 
-  tags = merge({ "Name" = "${var.name}-public" }, var.tags, local.dd_tags)
+  vpc_id     = aws_vpc.vpc.id
+  cidr_block = each.value.public_cidr
+
+  tags = merge({ "Name" = "${var.name}-${each.key}-public" }, var.tags, local.dd_tags)
 }
 
 resource "aws_eip" "nat" {
@@ -37,7 +50,8 @@ resource "aws_eip" "nat" {
 
 resource "aws_nat_gateway" "nat_gateway" {
   allocation_id = aws_eip.nat.id
-  subnet_id     = aws_subnet.public.id
+  # NAT gateway are expensive, keep only one until we can remove it entirely
+  subnet_id = values(aws_subnet.public)[0].id
 
   tags = merge({ "Name" = var.name }, var.tags, local.dd_tags)
 
@@ -57,15 +71,19 @@ resource "aws_route" "public" {
 }
 
 resource "aws_route_table_association" "public" {
-  subnet_id      = aws_subnet.public.id
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
   route_table_id = aws_route_table.public.id
 }
 
 resource "aws_subnet" "private" {
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = local.private_cidr
+  for_each = local.azs_cidrs
 
-  tags = merge({ "Name" = "${var.name}-private" }, var.tags, local.dd_tags)
+  vpc_id     = aws_vpc.vpc.id
+  cidr_block = each.value.private_cidr
+
+  tags = merge({ "Name" = "${var.name}-${each.key}-private" }, var.tags, local.dd_tags)
 }
 
 resource "aws_route_table" "private" {
@@ -81,7 +99,9 @@ resource "aws_route" "private" {
 }
 
 resource "aws_route_table_association" "private" {
-  subnet_id      = aws_subnet.private.id
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
   route_table_id = aws_route_table.private.id
 }
 
@@ -128,7 +148,7 @@ resource "aws_vpc_endpoint" "lambda" {
   service_name        = data.aws_vpc_endpoint_service.lambda.service_name
   vpc_endpoint_type   = data.aws_vpc_endpoint_service.lambda.service_type
   vpc_id              = aws_vpc.vpc.id
-  subnet_ids          = [aws_subnet.private.id]
+  subnet_ids          = [for s in aws_subnet.private : s.id]
   security_group_ids  = [aws_security_group.endpoint_sg.id]
   private_dns_enabled = true
 
@@ -144,7 +164,7 @@ resource "aws_vpc_endpoint" "ebs" {
   service_name        = data.aws_vpc_endpoint_service.ebs.service_name
   vpc_endpoint_type   = data.aws_vpc_endpoint_service.ebs.service_type
   vpc_id              = aws_vpc.vpc.id
-  subnet_ids          = [aws_subnet.private.id]
+  subnet_ids          = [for s in aws_subnet.private : s.id]
   security_group_ids  = [aws_security_group.endpoint_sg.id]
   private_dns_enabled = true
 
@@ -164,7 +184,7 @@ resource "aws_vpc_endpoint" "ssm" {
   service_name        = data.aws_vpc_endpoint_service.ssm[each.value].service_name
   vpc_endpoint_type   = data.aws_vpc_endpoint_service.ssm[each.value].service_type
   vpc_id              = aws_vpc.vpc.id
-  subnet_ids          = [aws_subnet.private.id]
+  subnet_ids          = [for s in aws_subnet.private : s.id]
   private_dns_enabled = true
   security_group_ids  = [aws_security_group.endpoint_sg.id]
 

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -36,8 +36,9 @@ resource "aws_internet_gateway" "internet_gateway" {
 resource "aws_subnet" "public" {
   for_each = local.azs_cidrs
 
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = each.value.public_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = each.key
+  cidr_block        = each.value.public_cidr
 
   tags = merge({ "Name" = "${var.name}-${each.key}-public" }, var.tags, local.dd_tags)
 }
@@ -80,8 +81,9 @@ resource "aws_route_table_association" "public" {
 resource "aws_subnet" "private" {
   for_each = local.azs_cidrs
 
-  vpc_id     = aws_vpc.vpc.id
-  cidr_block = each.value.private_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = each.key
+  cidr_block        = each.value.private_cidr
 
   tags = merge({ "Name" = "${var.name}-${each.key}-private" }, var.tags, local.dd_tags)
 }

--- a/modules/vpc/outputs.tf
+++ b/modules/vpc/outputs.tf
@@ -3,17 +3,27 @@ output "vpc" {
   value       = aws_vpc.vpc
 }
 
-output "public_subnet" {
-  description = "The public subnet of the created VPC"
+output "public_subnets" {
+  description = "The public subnets of the created VPC"
   value       = aws_subnet.public
 }
 
-output "private_subnet" {
-  description = "The private subnet of the created VPC"
+output "private_subnets" {
+  description = "The private subnets of the created VPC"
   value       = aws_subnet.private
 }
 
 output "nap_public_id" {
   description = "The public IP associated with the VPC's NAT"
   value       = aws_eip.nat.public_ip
+}
+
+output "routing_ready" {
+  description = "Allows to depends on completion of routing resources"
+  value       = true
+
+  depends_on = [
+    aws_route.private,
+    aws_route.public
+  ]
 }


### PR DESCRIPTION
This PR add the creation of multiple subnets for a maximum of 3 AZ in the region.
The ASG is now configured to start instance in any of these AZ and is waiting for the routing to be completely setup.