### PR TITLE
Force an instance shutdown on cloud-init error

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -197,6 +197,13 @@ Resources:
               set -e
               set -o pipefail
 
+              fatal_error () {
+                printf "FATAL ERROR: shutting down\n"
+                shutdown -h now
+              }
+
+              trap 'fatal_error' ERR
+
               # Enable the nbd module
               modprobe nbd nbds_max=128
               echo "nbd" > /etc/modules-load.d/nbd.conf

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -4,6 +4,13 @@ set -u
 set -e
 set -o pipefail
 
+fatal_error () {
+  printf "FATAL ERROR: shutting down\n"
+  shutdown -h now
+}
+
+trap 'fatal_error' ERR
+
 # Enable the nbd module
 modprobe nbd nbds_max=128
 echo "nbd" > /etc/modules-load.d/nbd.conf


### PR DESCRIPTION
Making sure that an instance that could not init properly (getting network issues for instance) is shutdown and recycled by our autoscaling policy.