### PR TITLE
Add IAM permission to allow decrypting snapshots using CMK

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -425,7 +425,21 @@ Resources:
             Action: 'ec2:DescribeVolumes'
             Effect: Allow
             Resource: '*'
-          - Sid: GetLambdaDetails
+          - Sid: DatadogAgentlessScannerDecryptEncryptedSnapshots
+            Action: 'kms:Decrypt'
+            Effect: Allow
+            Resource: 'arn:aws:kms:*:*:key/*'
+            Condition:
+              'ForAnyValue:StringEquals':
+                'kms:EncryptionContextKeys': 'aws:ebs:id'
+              StringLike:
+                'kms:EncryptionContext:aws:ebs:id': 'snap-*'
+                'kms:ViaService': 'ec2.*.amazonaws.com'
+          - Sid: DatadogAgentlessScannerKMSDescribe
+            Action: 'kms:DescribeKey'
+            Effect: Allow
+            Resource: 'arn:aws:kms:*:*:key/*'
+          - Sid: DatadogAgentlessScannerGetLambdaDetails
             Action: 'lambda:GetFunction'
             Effect: Allow
             Resource: 'arn:aws:lambda:*:*:function:*'

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -274,7 +274,41 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
   }
 
   statement {
-    sid    = "GetLambdaDetails"
+    sid       = "DatadogAgentlessScannerDecryptEncryptedSnapshots"
+    effect    = "Allow"
+    actions   = ["kms:Decrypt"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:key/*"]
+
+    // The following conditions enforce that decrypt action
+    // can only be performed on snapshots from calls by ebs API.
+    condition {
+      test     = "ForAnyValue:StringEquals"
+      variable = "kms:EncryptionContextKeys"
+      values   = ["aws:ebs:id"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:EncryptionContext:aws:ebs:id"
+      values   = ["snap-*"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "kms:ViaService"
+      values   = ["ec2.*.amazonaws.com"]
+    }
+  }
+
+  statement {
+    sid       = "DatadogAgentlessScannerKMSDescribe"
+    effect    = "Allow"
+    actions   = ["kms:DescribeKey"]
+    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:key/*"]
+  }
+
+  statement {
+    sid    = "DatadogAgentlessScannerGetLambdaDetails"
     effect = "Allow"
     actions = [
       "lambda:GetFunction",

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -277,7 +277,7 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
     sid       = "DatadogAgentlessScannerDecryptEncryptedSnapshots"
     effect    = "Allow"
     actions   = ["kms:Decrypt"]
-    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:key/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:kms:*:*:key/*"]
 
     // The following conditions enforce that decrypt action
     // can only be performed on snapshots from calls by ebs API.
@@ -304,7 +304,7 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
     sid       = "DatadogAgentlessScannerKMSDescribe"
     effect    = "Allow"
     actions   = ["kms:DescribeKey"]
-    resources = ["arn:${data.aws_partition.current.partition}:ec2:*:*:key/*"]
+    resources = ["arn:${data.aws_partition.current.partition}:kms:*:*:key/*"]
   }
 
   statement {

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -7,7 +7,7 @@ locals {
   }
 
   # Limit to a maximum of 3 AZs on that region
-  max_azs             = max(3, length(data.aws_availability_zones.available.names))
+  max_azs             = min(3, length(data.aws_availability_zones.available.names))
   private_cidr_offset = 3
   azs_cidrs = {
     for idx, az in slice(data.aws_availability_zones.available.names, 0, local.max_azs) :

--- a/modules/vpc/main.tf
+++ b/modules/vpc/main.tf
@@ -6,7 +6,8 @@ locals {
     DatadogAgentlessScanner = "true"
   }
 
-  max_azs             = 3 # Limit to a maximum of 3 AZs on that region
+  # Limit to a maximum of 3 AZs on that region
+  max_azs             = max(3, length(data.aws_availability_zones.available.names))
   private_cidr_offset = 3
   azs_cidrs = {
     for idx, az in slice(data.aws_availability_zones.available.names, 0, local.max_azs) :


### PR DESCRIPTION
This PR add 2 permissions:
* `kms:Decrypt`: this is required to read the snapshots that have been encrypted.
* `kms:DescribeKey`: this is required to find the key used by the snapshot.
