### PR TITLE
Bump agentless-scanner version to 7.53.0-agentless-scanner-2024032202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Version TBD
 
+### agentless-scanner 2024032202
+
+- Bump Trivy to version 2024-02-28.
+
 ### Terraform
 
 - Add missing CopySnapshot permissions to allow AMI scanning

--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -260,8 +260,8 @@ Resources:
               DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
               DD_SITE="${DatadogSite}"
               DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
-              DD_AGENT_MINOR_VERSION="50.3"
-              DD_SCANNER_VERSION="7.51.0~agentless~scanner~2024022201"
+              DD_AGENT_MINOR_VERSION="52.0"
+              DD_SCANNER_VERSION="7.53.0~agentless~scanner~2024032202"
 
               hostnamectl hostname $DD_HOSTNAME
 

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -8,8 +8,8 @@ locals {
 data "aws_region" "current" {}
 
 locals {
-  agent_version      = "50.3"
-  scanner_version    = "7.51.0~agentless~scanner~2024022201"
+  agent_version      = "52.0"
+  scanner_version    = "7.53.0~agentless~scanner~2024032202"
   api_key_secret_arn = var.api_key_secret_arn != null ? var.api_key_secret_arn : aws_secretsmanager_secret.api_key[0].arn
 }
 


### PR DESCRIPTION
This change bumps `agentless-scanner` version to `7.53.0-agentless-scanner-2024032202`.