### PR TITLE
Encrypted snapshots: allow granting KMS keys for AWS resources

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -424,6 +424,22 @@ Resources:
             Action: 'ec2:DescribeSnapshots'
             Effect: Allow
             Resource: '*'
+          - Sid: DatadogAgentlessScannerEncryptedCopyGrant
+            Action: 'kms:CreateGrant'
+            Effect: Allow
+            Resource: 'arn:aws:kms:*:*:key/*'
+            Condition:
+              'ForAnyValue:StringEquals':
+                'kms:EncryptionContextKeys': 'aws:ebs:id'
+              StringLike:
+                'kms:EncryptionContext:aws:ebs:id': 'snap-*'
+                'kms:ViaService': 'ec2.*.amazonaws.com'
+              Bool:
+                'kms:GrantIsForAWSResource': true
+          - Sid: DatadogAgentlessScannerEncryptedCopyDescribe
+            Action: 'kms:DescribeKey'
+            Effect: Allow
+            Resource: 'arn:aws:kms:*:*:key/*'
 
   ScannerDelegateRoleWorkerPolicy:
     Type: AWS::IAM::ManagedPolicy


### PR DESCRIPTION
This PR adds in the orchestrator policy the ability to `kms:CreateGrant` (limited by `kms:GrantIsForAWSResource`) in order to be able to copy snapshots encrypted with customer-managed keys.

This should solve the following error:

```
waiting for copied snapshot "arn:aws:ec2:xxx:xxx:snapshot/snap-xxx": snapshot "snap-xxx" failed: Given key ID is not accessible
```

Note that we're NOT adding this capability to the worker policy. This is a permission that only apply for the write-only orchestrator.