### PR TITLE
Auto-update the datadog-agentless-scanner package

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -289,10 +289,10 @@ Resources:
               agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
               agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)"
               if [ -z "$agentless_version_custom" ]; then
-                printf "Could not find a version of datadog-agentless-scanner from $DD_AGENTLESS_VERSION"
+                printf "Could not find a version of datadog-agentless-scanner from %s" "$DD_AGENTLESS_VERSION"
                 exit 1
               fi
-              apt install -y datadog-agentless-scanner=$agentless_version_custom
+              apt install -y "datadog-agentless-scanner=$agentless_version_custom"
 
               # Adding automatic reboot on kernel updates
               cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades

--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -267,25 +267,32 @@ Resources:
               DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
               DD_SITE="${DatadogSite}"
               DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
-              DD_AGENT_MINOR_VERSION="52.0"
-              DD_SCANNER_VERSION="0.11.0"
+              DD_AGENT_MINOR_VERSION="53.0"
+              DD_AGENTLESS_VERSION="0.11"
 
-              hostnamectl hostname $DD_HOSTNAME
+              hostnamectl hostname "$DD_HOSTNAME"
 
               # Install the agent
-              DD_API_KEY=$DD_API_KEY \
+              DD_API_KEY="$DD_API_KEY" \
                 DD_SITE="$DD_SITE" \
                 DD_HOSTNAME="$DD_HOSTNAME" \
                 DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
                 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
-              # Install the agentless-scanner
-              curl -sL -o "/tmp/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb" "https://apt.datadoghq.com/pool/d/da/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb"
-              dpkg -i "/tmp/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb"
-
               # Patch agent configuration
               sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml
               sed -i '/.*ec2_prefer_imdsv2:.*/a ec2_prefer_imdsv2: true' /etc/datadog-agent/datadog.yaml
+
+              # Install the agentless-scanner
+              echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog-agent.list
+              apt update
+              agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
+              agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)"
+              if [ -z "$agentless_version_custom" ]; then
+                printf "Could not find a version of datadog-agentless-scanner from $DD_AGENTLESS_VERSION"
+                exit 1
+              fi
+              apt install -y datadog-agentless-scanner=$agentless_version_custom
 
               # Adding automatic reboot on kernel updates
               cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades
@@ -306,16 +313,6 @@ Resources:
               EOF
 
               chown -R dd-agent: /etc/datadog-agent/conf.d/agentless-scanner.d
-
-              if [ "$DD_SITE" = "datad0g.com" ]; then
-                cat <<EOF >> /etc/datadog-agent/datadog.yaml
-              # Remote configuration keys for staging
-              remote_configuration:
-                enabled: true
-                config_root: '{"signatures":[{"keyid":"6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e","sig":"4af18f0919fb9b8ba7ffc9f6fb325c887083c28a474981e29ccc5bdeea7a2bf2f8568be8f8bd3c6c498dd118e2c8f713d22032196cf400465f8fb700ba800f0d"},{"keyid":"bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","sig":"2e6bb516308fd8c79faff015a443b65dea0af780842aacc5c05f49ae8fd709bfdd70e191a38d0b64aad03bb4398052b82bd224d6e55c90d4c38220aa9db62705"}],"signed":{"_type":"root","consistent_snapshot":true,"expires":"1970-01-01T00:00:00Z","keys":{"6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"09402247ef6252018e52c7ba6a3a484936f14dad6ae921c556a1d092f4a68f0f"},"scheme":"ed25519"},"bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"cf248bc222a5dfc9676a2a3ef90526c84adb09649db56686705f69f42908d7d8"},"scheme":"ed25519"}},"roles":{"root":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2},"snapshot":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2},"targets":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2},"timestamp":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2}},"spec_version":"1.0","version":1}}'
-                director_root: '{"signatures":[{"keyid":"233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6","sig":"6d7ddf4bcbd1ce223b5352cae4671ef42800d79f0c94dda905cf0dd8a6198ba69795a19201dc7230e4bd872cf109e827233678bf76389910933472417488320e"},{"keyid":"6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","sig":"a1236d12903e1c4024fc6340c50a0f2fe9972e967eb2bace8d6594e156f0466f772bfc0c9f30e07067904073c0d7ba7d48ad00341405312daf0d7bc502ccc50f"}],"signed":{"_type":"root","consistent_snapshot":true,"expires":"1970-01-01T00:00:00Z","keys":{"233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"f7c278f32e69ce7d5ca5b81bd2cbe2b4b44177eee36ed025ec06bd19e47eaefe"},"scheme":"ed25519"},"6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"47be15ec10499208aa5ef9a1e32010cc05c047a98d18ad084d6e4e51baa1b93c"},"scheme":"ed25519"}},"roles":{"root":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2},"snapshot":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2},"targets":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2},"timestamp":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2}},"spec_version":"1.0","version":1}}'
-              EOF
-              fi
 
               cat <<EOF >> /etc/datadog-agent/agentless-scanner.yaml
               hostname: $DD_HOSTNAME

--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -284,7 +284,7 @@ Resources:
               sed -i '/.*ec2_prefer_imdsv2:.*/a ec2_prefer_imdsv2: true' /etc/datadog-agent/datadog.yaml
 
               # Install the agentless-scanner
-              echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog-agent.list
+              echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
               apt update
               agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
               agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)"

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -9,7 +9,7 @@ data "aws_region" "current" {}
 
 locals {
   agent_version      = "53.0"
-  scanner_version    = "0.11.0"
+  scanner_version    = "0.11"
   api_key_secret_arn = var.api_key_secret_arn != null ? var.api_key_secret_arn : aws_secretsmanager_secret.api_key[0].arn
 }
 

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -8,7 +8,7 @@ locals {
 data "aws_region" "current" {}
 
 locals {
-  agent_version      = "52.0"
+  agent_version      = "53.0"
   scanner_version    = "0.11.0"
   api_key_secret_arn = var.api_key_secret_arn != null ? var.api_key_secret_arn : aws_secretsmanager_secret.api_key[0].arn
 }

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -59,7 +59,7 @@ sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/da
 sed -i '/.*ec2_prefer_imdsv2:.*/a ec2_prefer_imdsv2: true' /etc/datadog-agent/datadog.yaml
 
 # Install the agentless-scanner
-echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog-agent.list
+echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
 apt update
 agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
 agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)"

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -64,10 +64,10 @@ apt update
 agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
 agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)"
 if [ -z "$agentless_version_custom" ]; then
-  printf 1>&2 "Could not find a version of datadog-agentless-scanner from $DD_AGENTLESS_VERSION"
+  printf "Could not find a version of datadog-agentless-scanner from %s" "$DD_AGENTLESS_VERSION"
   exit 1
 fi
-apt install -y datadog-agentless-scanner=$agentless_version_custom
+apt install -y "datadog-agentless-scanner=$agentless_version_custom"
 
 # Adding automatic reboot on kernel updates
 cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 fatal_error () {
-  printf "FATAL ERROR: shutting down\n"
+  printf 2>&1 "FATAL ERROR: shutting down\n"
   shutdown -h now
 }
 
@@ -43,24 +43,31 @@ DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
 DD_SITE="${site}"
 DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
 DD_AGENT_MINOR_VERSION="${agent_version}"
-DD_SCANNER_VERSION="${scanner_version}"
+DD_AGENTLESS_VERSION="${scanner_version}"
 
 hostnamectl hostname "$DD_HOSTNAME"
 
 # Install the agent
 DD_API_KEY="$DD_API_KEY" \
-  DD_HOSTNAME="$DD_HOSTNAME" \
   DD_SITE="$DD_SITE" \
+  DD_HOSTNAME="$DD_HOSTNAME" \
   DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
-
-# Install the agentless-scanner
-curl -sL -o "/tmp/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb" "https://apt.datadoghq.com/pool/d/da/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb"
-dpkg -i "/tmp/datadog-agentless-scanner_$DD_SCANNER_VERSION-1_arm64.deb"
 
 # Patch agent configuration
 sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml
 sed -i '/.*ec2_prefer_imdsv2:.*/a ec2_prefer_imdsv2: true' /etc/datadog-agent/datadog.yaml
+
+# Install the agentless-scanner
+echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog-agent.list
+apt update
+agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
+agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)"
+if [ -z "$agentless_version_custom" ]; then
+  printf 1>&2 "Could not find a version of datadog-agentless-scanner from $DD_AGENTLESS_VERSION"
+  exit 1
+fi
+apt install -y datadog-agentless-scanner=$agentless_version_custom
 
 # Adding automatic reboot on kernel updates
 cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades
@@ -81,15 +88,6 @@ logs:
 EOF
 
 chown -R dd-agent: /etc/datadog-agent/conf.d/agentless-scanner.d
-
-if [ "$DD_SITE" = "datad0g.com" ]; then
-cat <<EOF >> /etc/datadog-agent/datadog.yaml
-remote_configuration:
-  enabled: true
-  config_root: '{"signatures":[{"keyid":"6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e","sig":"4af18f0919fb9b8ba7ffc9f6fb325c887083c28a474981e29ccc5bdeea7a2bf2f8568be8f8bd3c6c498dd118e2c8f713d22032196cf400465f8fb700ba800f0d"},{"keyid":"bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","sig":"2e6bb516308fd8c79faff015a443b65dea0af780842aacc5c05f49ae8fd709bfdd70e191a38d0b64aad03bb4398052b82bd224d6e55c90d4c38220aa9db62705"}],"signed":{"_type":"root","consistent_snapshot":true,"expires":"1970-01-01T00:00:00Z","keys":{"6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"09402247ef6252018e52c7ba6a3a484936f14dad6ae921c556a1d092f4a68f0f"},"scheme":"ed25519"},"bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"cf248bc222a5dfc9676a2a3ef90526c84adb09649db56686705f69f42908d7d8"},"scheme":"ed25519"}},"roles":{"root":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2},"snapshot":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2},"targets":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2},"timestamp":{"keyids":["bd3ea764afdf757f07bab1e9e501a5fda1d49a8da3eaddc53a50dbe2aff92545","6aac6a51efedb4e54915bf9fbd2cfb49fbf428d46052bcaf3c72409c33ecdf5e"],"threshold":2}},"spec_version":"1.0","version":1}}'
-  director_root: '{"signatures":[{"keyid":"233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6","sig":"6d7ddf4bcbd1ce223b5352cae4671ef42800d79f0c94dda905cf0dd8a6198ba69795a19201dc7230e4bd872cf109e827233678bf76389910933472417488320e"},{"keyid":"6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","sig":"a1236d12903e1c4024fc6340c50a0f2fe9972e967eb2bace8d6594e156f0466f772bfc0c9f30e07067904073c0d7ba7d48ad00341405312daf0d7bc502ccc50f"}],"signed":{"_type":"root","consistent_snapshot":true,"expires":"1970-01-01T00:00:00Z","keys":{"233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"f7c278f32e69ce7d5ca5b81bd2cbe2b4b44177eee36ed025ec06bd19e47eaefe"},"scheme":"ed25519"},"6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1":{"keyid_hash_algorithms":["sha256","sha512"],"keytype":"ed25519","keyval":{"public":"47be15ec10499208aa5ef9a1e32010cc05c047a98d18ad084d6e4e51baa1b93c"},"scheme":"ed25519"}},"roles":{"root":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2},"snapshot":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2},"targets":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2},"timestamp":{"keyids":["6ca796e7b4883af3bb3d522dc0009984dcbf5ad2a6c9ea354d30acc32d8b75d1","233a529fe7c63b5b9081f6e0e2681cc227f85e04ad434d0a165a2f69b87255a6"],"threshold":2}},"spec_version":"1.0","version":1}}'
-EOF
-fi
 
 cat <<EOF >> /etc/datadog-agent/agentless-scanner.yaml
 hostname: $DD_HOSTNAME

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -52,7 +52,7 @@ DD_API_KEY="$DD_API_KEY" \
   DD_SITE="$DD_SITE" \
   DD_HOSTNAME="$DD_HOSTNAME" \
   DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
-  bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"›
+  bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 # Patch agent configuration
 sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 fatal_error () {
-  printf 2>&1 "FATAL ERROR: shutting down\n"
+  printf "FATAL ERROR: shutting down\n"
   shutdown -h now
 }
 
@@ -52,7 +52,7 @@ DD_API_KEY="$DD_API_KEY" \
   DD_SITE="$DD_SITE" \
   DD_HOSTNAME="$DD_HOSTNAME" \
   DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
-  bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
+  bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"›
 
 # Patch agent configuration
 sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml


### PR DESCRIPTION
- rely on APT to install the datadog-agentless-scanner package
- install the latest version matching the pinned MAJOR.MINOR version
- upgrade datadog-agent to 7.53.0
- remove the RC staging root keys from user_data