### PR TITLE
aws: lambda: add layer scanning perms

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -505,7 +505,7 @@ Resources:
             Action: 'lambda:GetFunction'
             Effect: Allow
             Resource: 'arn:aws:lambda:*:*:function:*'
-          - Sid: DatadogAgentlessScannerGetLambdaDetails
+          - Sid: DatadogAgentlessScannerGetLambdaLayerDetails
             Action: 'lambda:GetLayerVersionByArn'
             Effect: Allow
             Resource: 'arn:aws:lambda:*:*:layer:*:*'

--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -505,6 +505,10 @@ Resources:
             Action: 'lambda:GetFunction'
             Effect: Allow
             Resource: 'arn:aws:lambda:*:*:function:*'
+          - Sid: DatadogAgentlessScannerGetLambdaDetails
+            Action: 'lambda:GetLayerVersionByArn'
+            Effect: Allow
+            Resource: 'arn:aws:lambda:*:*:layer:*:*'
 
   ScannerDelegateOfflineRolePolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -363,6 +363,23 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
       values   = ["false"]
     }
   }
+
+  statement {
+    sid    = "DatadogAgentlessScannerGetLambdaLayersDetails"
+    effect = "Allow"
+    actions = [
+      "lambda:GetLayerVersionByArn",
+    ]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:lambda:*:*:layer:*:*"
+    ]
+    // Forbid scanning lambdas that does have a DatadogAgentlessScanner:false tag.
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:ResourceTag/DatadogAgentlessScanner"
+      values   = ["false"]
+    }
+  }
 }
 
 resource "aws_iam_policy" "scanning_orchestrator_policy" {

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -365,7 +365,7 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
   }
 
   statement {
-    sid    = "DatadogAgentlessScannerGetLambdaLayersDetails"
+    sid    = "DatadogAgentlessScannerGetLambdaLayerDetails"
     effect = "Allow"
     actions = [
       "lambda:GetLayerVersionByArn",


### PR DESCRIPTION
Add permissions to scan lambda layers for Datadog/datadog-agentless-scanner#8