### PR TITLE
Add access to s3 buckets for DSPM

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -41,6 +41,15 @@ Parameters:
       Enable Agentless Scanning of Lambda vulnerabilities. "CloudSecurityPostureManagement" must be set to 'true'.
     Default: false
 
+  AgentlessDatastoresScanning:
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Description: >-
+      Enable Agentless Scanning of datastores (S3 buckets, RDS databases). "CloudSecurityPostureManagement" must be set to 'true'.
+    Default: false
+
   DatadogAPIKeySecretArn:
     Type: String
     Description: The ARN of the secret storing the Datadog API key, if you already have it stored in Secrets Manager. You must store the secret as a plaintext, rather than a key-value pair.
@@ -148,6 +157,9 @@ Conditions:
     - ''
   OfflineModeEnabled: !Equals
     - !Ref 'ScannerOfflineModeEnabled'
+    - 'true'
+  DSPMEnabled: !Equals
+    - !Ref 'AgentlessDatastoresScanning'
     - 'true'
 
 Rules:
@@ -533,6 +545,32 @@ Resources:
               StringNotEquals:
                 'aws:ResourceTag/DatadogAgentlessScanner': 'false'
 
+  ScannerDelegateRoleWorkerDSPMPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: DSPMEnabled
+    Properties:
+      Description: Policy for the Datadog Agentless Scanner worker allowing the listing and reading of S3 buckets.
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: DatadogAgentlessScannerAccessS3Objects
+            Action: 's3:GetObject'
+            Effect: Allow
+            Resource: 'arn:aws:s3:::*/*'
+          - Sid: DatadogAgentlessScannerListS3Buckets
+            Action: 's3:ListBucket'
+            Effect: Allow
+            Resource: 'arn:aws:s3:::*'
+          - Sid: DatadogAgentlessScannerDecryptS3Objects
+            Action:
+              - 'kms:Decrypt'
+              - 'kms:GenerateDataKey'
+            Effect: Allow
+            Resource: 'arn:aws:kms:*:*:key/*'
+            Condition:
+              StringLike:
+                'kms:ViaService': 's3.*.amazonaws.com'
+
   ScannerDelegateOfflineRolePolicy:
     Type: AWS::IAM::ManagedPolicy
     Properties:
@@ -558,6 +596,14 @@ Resources:
             Resource: '*'
           - Sid: DatadogAgentlessScannerOfflineModeListImages
             Action: ec2:DescribeImages
+            Effect: Allow
+            Resource: '*'
+          - Sid: DatadogAgentlessScannerOfflineModeListAllMyBuckets
+            Action: s3:ListAllMyBuckets
+            Effect: Allow
+            Resource: '*'
+          - Sid: DatadogAgentlessScannerOfflineModeGetBucketTags
+            Action: s3:GetBucketTagging
             Effect: Allow
             Resource: '*'
 
@@ -603,6 +649,7 @@ Resources:
       ManagedPolicyArns:
         - !Ref 'ScannerDelegateRoleOrchestratorPolicy'
         - !Ref 'ScannerDelegateRoleWorkerPolicy'
+        - !If [DSPMEnabled, !Ref 'ScannerDelegateRoleWorkerDSPMPolicy', !Ref 'AWS::NoValue']
         - !If [OfflineModeEnabled, !Ref 'ScannerDelegateOfflineRolePolicy', !Ref 'AWS::NoValue']
       Description: Role assumed by the Datadog Agentless scanner agent to perform scans
       Tags:

--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -21,12 +21,15 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.scanning_orchestrator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.scanning_worker_dspm_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.scanning_worker_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.orchestrator_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.worker_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.workers_dspm_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.scanning_orchestrator_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.scanning_worker_dspm_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.scanning_worker_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
@@ -34,6 +37,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_datastores_scanning_enabled"></a> [datastores\_scanning\_enabled](#input\_datastores\_scanning\_enabled) | Installs specific permissions to enable scanning of datastores (S3 buckets and RDS instances) | `bool` | `false` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerDelegateRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role and policies path | `string` | `"/"` | no |
 | <a name="input_scanner_roles"></a> [scanner\_roles](#input\_scanner\_roles) | List of roles ARN allowed to assume this role | `list(string)` | n/a | yes |

--- a/modules/scanning-delegate-role/variables.tf
+++ b/modules/scanning-delegate-role/variables.tf
@@ -10,6 +10,12 @@ variable "iam_role_path" {
   default     = "/"
 }
 
+variable "datastores_scanning_enabled" {
+  description = "Installs specific permissions to enable scanning of datastores (S3 buckets and RDS instances)"
+  type        = bool
+  default     = false
+}
+
 variable "scanner_roles" {
   description = "List of roles ARN allowed to assume this role"
   type        = list(string)


### PR DESCRIPTION
Add opt-ins to allow accessing AWS datastores like S3 buckets.