### PR TITLE
Azure: improve Key Vault secret handling

### DIFF
--- a/modules/azure/provider.tf
+++ b/modules/azure/provider.tf
@@ -2,6 +2,10 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
+    azapi = {
+      source  = "Azure/azapi"
+      version = "1.13.1"
+    }
     azurerm = {
       source  = "hashicorp/azurerm"
       version = "3.101.0"

--- a/modules/azure/variables.tf
+++ b/modules/azure/variables.tf
@@ -16,14 +16,8 @@ variable "api_key" {
   default     = null
 }
 
-variable "api_key_vault_id" {
-  description = "The resource ID of the Key Vault holding the Datadog API key. Ignored if api_key is specified."
-  type        = string
-  default     = null
-}
-
-variable "api_key_secret_name" {
-  description = "The name of the secret in the Key Vault holding the Datadog API key. Ignored if api_key is specified."
+variable "api_key_secret_id" {
+  description = "The versionless resource ID of the Azure Key Vault secret holding the Datadog API key. Ignored if api_key is specified."
   type        = string
   default     = null
 }


### PR DESCRIPTION
Use the `azapi` provider to handle KV secrets in a better way:
  1. User applying the TF no longer needs Key Vault Secrets User role and the secret is not stored in TF state
  3. Only need to specify one variable (secret resource ID) instead of two (vault ID and secret name)