### PR TITLE
TF: add validation on api_key_secret_arns to be non-empty

### DIFF
--- a/modules/agentless-scanner-role/variables.tf
+++ b/modules/agentless-scanner-role/variables.tf
@@ -31,6 +31,10 @@ variable "account_roles" {
 variable "api_key_secret_arns" {
   description = "List of ARNs of the secrets holding the Datadog API keys"
   type        = list(string)
+  validation {
+    condition     = length(var.api_key_secret_arns) > 0
+    error_message = "api_key_secret_arns must not be empty"
+  }
 }
 
 variable "api_key_secret_kms_key_arns" {


### PR DESCRIPTION
Making sure the scanner's instance role is able to access at least one API key.