### PR TITLE
Add `scanner_channel` parameter in Azure

### DIFF
--- a/modules/azure/custom-data/README.md
+++ b/modules/azure/custom-data/README.md
@@ -28,6 +28,7 @@ No modules.
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | n/a | yes |
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | Client ID of the managed identity used by the Datadog Agentless Scanner | `string` | n/a | yes |
 | <a name="input_location"></a> [location](#input\_location) | The location of the resource group where the Datadog Agentless Scanner resources will be created | `string` | n/a | yes |
+| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta) | `string` | `"stable"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 
 ## Outputs

--- a/modules/azure/custom-data/main.tf
+++ b/modules/azure/custom-data/main.tf
@@ -10,6 +10,7 @@ resource "terraform_data" "template" {
     azure_client_id = var.client_id,
     agent_version   = local.agent_version,
     scanner_version = local.scanner_version,
+    scanner_channel = var.scanner_channel,
     region          = var.location,
   })
 }

--- a/modules/azure/custom-data/templates/install.sh.tftpl
+++ b/modules/azure/custom-data/templates/install.sh.tftpl
@@ -36,6 +36,7 @@ DD_HOSTNAME="$(hostname)"
 DD_SITE="${site}"
 DD_AGENT_MINOR_VERSION="${agent_version}"
 DD_AGENTLESS_VERSION="${scanner_version}"
+DD_AGENTLESS_CHANNEL="${scanner_channel}"
 
 hostnamectl hostname "$DD_HOSTNAME"
 
@@ -50,7 +51,7 @@ DD_API_KEY="$DD_API_KEY" \
 sed -i '/.*logs_enabled:.*/a logs_enabled: true'           /etc/datadog-agent/datadog.yaml
 
 # Install the agentless-scanner
-echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ stable agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
+echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ $DD_AGENTLESS_CHANNEL agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
 apt update
 agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(-[[:digit:]])?"
 agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)" || true

--- a/modules/azure/custom-data/variables.tf
+++ b/modules/azure/custom-data/variables.tf
@@ -21,3 +21,13 @@ variable "client_id" {
   type        = string
   nullable    = false
 }
+
+variable "scanner_channel" {
+  description = "Channel of the scanner to install from (stable or beta)"
+  type        = string
+  default     = "stable"
+  validation {
+    condition     = contains(["stable", "beta"], var.scanner_channel)
+    error_message = "The scanner channel must be either 'stable' or 'beta'"
+  }
+}


### PR DESCRIPTION
Staying in sync with our AWS user_data allowing to use a beta channel.