### PR TITLE
Do not pin to a specific agent minror version to allow auto-upgrade

### DIFF
--- a/cloudformation/main.yaml
+++ b/cloudformation/main.yaml
@@ -293,7 +293,6 @@ Resources:
               DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
               DD_SITE="${DatadogSite}"
               DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
-              DD_AGENT_MINOR_VERSION="53.0"
               DD_AGENTLESS_VERSION="${ScannerVersion}"
               DD_AGENTLESS_CHANNEL="${ScannerChannel}"
 
@@ -303,7 +302,6 @@ Resources:
               DD_API_KEY="$DD_API_KEY" \
                 DD_SITE="$DD_SITE" \
                 DD_HOSTNAME="$DD_HOSTNAME" \
-                DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
                 bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
               # Patch agent configuration

--- a/modules/azure/custom-data/README.md
+++ b/modules/azure/custom-data/README.md
@@ -34,7 +34,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_agent_version"></a> [agent\_version](#output\_agent\_version) | The version of the Datadog Agent installed |
 | <a name="output_install_sh"></a> [install\_sh](#output\_install\_sh) | The installation script for the Datadog agentless scanner |
 | <a name="output_scanner_version"></a> [scanner\_version](#output\_scanner\_version) | The version of the Datadog Agentless Scanner installed |
 <!-- END_TF_DOCS -->

--- a/modules/azure/custom-data/main.tf
+++ b/modules/azure/custom-data/main.tf
@@ -1,5 +1,4 @@
 locals {
-  agent_version   = "53.0"
   scanner_version = "0.11"
 }
 
@@ -8,7 +7,6 @@ resource "terraform_data" "template" {
     api_key         = var.api_key
     site            = var.site,
     azure_client_id = var.client_id,
-    agent_version   = local.agent_version,
     scanner_version = local.scanner_version,
     region          = var.location,
   })

--- a/modules/azure/custom-data/outputs.tf
+++ b/modules/azure/custom-data/outputs.tf
@@ -3,11 +3,6 @@ output "install_sh" {
   value       = terraform_data.template.output
 }
 
-output "agent_version" {
-  description = "The version of the Datadog Agent installed"
-  value       = local.agent_version
-}
-
 output "scanner_version" {
   description = "The version of the Datadog Agentless Scanner installed"
   value       = local.scanner_version

--- a/modules/azure/custom-data/templates/install.sh.tftpl
+++ b/modules/azure/custom-data/templates/install.sh.tftpl
@@ -34,7 +34,6 @@ fi
 
 DD_HOSTNAME="$(hostname)"
 DD_SITE="${site}"
-DD_AGENT_MINOR_VERSION="${agent_version}"
 DD_AGENTLESS_VERSION="${scanner_version}"
 
 hostnamectl hostname "$DD_HOSTNAME"
@@ -43,7 +42,6 @@ hostnamectl hostname "$DD_HOSTNAME"
 DD_API_KEY="$DD_API_KEY" \
   DD_SITE="$DD_SITE" \
   DD_HOSTNAME="$DD_HOSTNAME" \
-  DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 # Patch agent configuration

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -41,7 +41,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_agent_version"></a> [agent\_version](#output\_agent\_version) | The version of the Datadog Agent installed |
 | <a name="output_api_key_secret_arn"></a> [api\_key\_secret\_arn](#output\_api\_key\_secret\_arn) | The ARN of the API key secret |
 | <a name="output_install_sh"></a> [install\_sh](#output\_install\_sh) | The installation script for the Datadog agentless scanner |
 | <a name="output_scanner_version"></a> [scanner\_version](#output\_scanner\_version) | The version of the Datadog Agentless Scanner installed |

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -8,7 +8,6 @@ locals {
 data "aws_region" "current" {}
 
 locals {
-  agent_version      = "53.0"
   api_key_secret_arn = var.api_key_secret_arn != null ? var.api_key_secret_arn : aws_secretsmanager_secret.api_key[0].arn
 }
 
@@ -35,7 +34,6 @@ resource "terraform_data" "template" {
   input = templatefile("${path.module}/templates/install.sh.tftpl", {
     api_key_secret_arn = local.api_key_secret_arn
     site               = var.site,
-    agent_version      = local.agent_version,
     scanner_version    = var.scanner_version,
     scanner_channel    = var.scanner_channel,
     region             = data.aws_region.current.name,

--- a/modules/user_data/outputs.tf
+++ b/modules/user_data/outputs.tf
@@ -8,11 +8,6 @@ output "api_key_secret_arn" {
   value       = local.api_key_secret_arn
 }
 
-output "agent_version" {
-  description = "The version of the Datadog Agent installed"
-  value       = local.agent_version
-}
-
 output "scanner_version" {
   description = "The version of the Datadog Agentless Scanner installed"
   value       = var.scanner_version

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -42,7 +42,6 @@ AWS_SECRET_JSON=$(curl --noproxy '*' -sSL -X POST "https://secretsmanager.$IMDS_
 DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
 DD_SITE="${site}"
 DD_API_KEY="$(jq -r '.SecretString' <<< "$AWS_SECRET_JSON")"
-DD_AGENT_MINOR_VERSION="${agent_version}"
 DD_AGENTLESS_VERSION="${scanner_version}"
 DD_AGENTLESS_CHANNEL="${scanner_channel}"
 
@@ -52,7 +51,6 @@ hostnamectl hostname "$DD_HOSTNAME"
 DD_API_KEY="$DD_API_KEY" \
   DD_SITE="$DD_SITE" \
   DD_HOSTNAME="$DD_HOSTNAME" \
-  DD_AGENT_MINOR_VERSION="$DD_AGENT_MINOR_VERSION" \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 # Patch agent configuration


### PR DESCRIPTION
Let's not pin to a specific minor version of the Agent and also activate auto-upgrade for this component.