### PR TITLE
Azure: enable reimaging of VMs on upgrade

### DIFF
--- a/modules/azure/CHANGELOG.md
+++ b/modules/azure/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Switch to Uniform Orchestration mode Scale Set
 - Enable automatic reimaging of VMs on upgrade
+- Enable Azure boot diagnostics

--- a/modules/azure/CHANGELOG.md
+++ b/modules/azure/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Version TBD
+
+- Switch to Uniform Orchestration mode Scale Set
+- Enable automatic reimaging of VMs on upgrade

--- a/modules/azure/virtual-machine/README.md
+++ b/modules/azure/virtual-machine/README.md
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_orchestrated_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/orchestrated_virtual_machine_scale_set) | resource |
+| [azurerm_linux_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/linux_virtual_machine_scale_set) | resource |
 
 ## Inputs
 

--- a/modules/azure/virtual-machine/main.tf
+++ b/modules/azure/virtual-machine/main.tf
@@ -28,6 +28,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     username   = var.admin_username
     public_key = var.admin_ssh_key
   }
+  boot_diagnostics {}
 
   os_disk {
     caching              = "ReadWrite"

--- a/modules/azure/virtual-machine/main.tf
+++ b/modules/azure/virtual-machine/main.tf
@@ -5,15 +5,14 @@ locals {
   }
 }
 
-resource "azurerm_orchestrated_virtual_machine_scale_set" "vmss" {
+resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
   name                = var.name
   location            = var.location
   resource_group_name = var.resource_group_name
   tags                = merge(var.tags, local.dd_tags)
 
-  sku_name                    = var.instance_size
-  instances                   = var.instance_count
-  platform_fault_domain_count = 1
+  sku       = var.instance_size
+  instances = var.instance_count
 
   identity {
     type = "UserAssigned"
@@ -21,18 +20,15 @@ resource "azurerm_orchestrated_virtual_machine_scale_set" "vmss" {
       var.user_assigned_identity
     ]
   }
-  os_profile {
-    linux_configuration {
-      computer_name_prefix            = "agentless-scanning-"
-      admin_username                  = var.admin_username
-      disable_password_authentication = true
-      admin_ssh_key {
-        username   = var.admin_username
-        public_key = var.admin_ssh_key
-      }
-    }
-    custom_data = base64encode(var.custom_data)
+
+  computer_name_prefix = "agentless-scanning-"
+  custom_data          = base64encode(var.custom_data)
+  admin_username       = var.admin_username
+  admin_ssh_key {
+    username   = var.admin_username
+    public_key = var.admin_ssh_key
   }
+
   os_disk {
     caching              = "ReadWrite"
     storage_account_type = "StandardSSD_LRS"


### PR DESCRIPTION
The azurerm provider does not support `reimage_on_manual_upgrade` for
flexible orchestration scale sets. This makes for a pretty miserable
upgrade experience.

The differences between flexible and uniform scale sets are not super
relevant to us, so let's just switch to uniform for the time being.