### PR TITLE
Azure: enable automatic instance repairs

### DIFF
--- a/modules/azure/CHANGELOG.md
+++ b/modules/azure/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version TBD
 
+- Enable automatic instance repairs
 - Allow specifying custom configuration for the agent and scanner
 - Switch to Uniform Orchestration mode Scale Set
 - Enable automatic reimaging of VMs on upgrade

--- a/modules/azure/virtual-machine/main.tf
+++ b/modules/azure/virtual-machine/main.tf
@@ -53,6 +53,10 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     }
   }
 
+  automatic_instance_repair {
+    enabled      = true
+    grace_period = "PT10M"
+  }
   extension {
     name                 = "HealthExtension"
     publisher            = "Microsoft.ManagedServices"

--- a/modules/azure/virtual-machine/main.tf
+++ b/modules/azure/virtual-machine/main.tf
@@ -35,12 +35,14 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     storage_account_type = "StandardSSD_LRS"
     disk_size_gb         = var.instance_root_volume_size
   }
+
   source_image_reference {
     publisher = "canonical"
     offer     = "0001-com-ubuntu-server-jammy"
     sku       = "22_04-lts-arm64"
     version   = "latest"
   }
+
   network_interface {
     name    = "nic"
     primary = true
@@ -49,5 +51,19 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
       primary   = true
       subnet_id = var.subnet_id
     }
+  }
+
+  extension {
+    name                 = "HealthExtension"
+    publisher            = "Microsoft.ManagedServices"
+    type                 = "ApplicationHealthLinux"
+    type_handler_version = "1.0"
+    settings = jsonencode({
+      protocol          = "http",
+      port              = 6253,
+      requestPath       = "/health"
+      intervalInSeconds = 10
+      numberOfProbes    = 3
+    })
   }
 }


### PR DESCRIPTION
We will reimage/replace the instance if it fails health checks for 10 minutes.

Once DataDog/datadog-agentless-scanner#54 (rich health states) is released, we can lower this to 5 minutes or so.