### PR TITLE
Azure: append VM ID to hostname

### DIFF
--- a/modules/azure/custom-data/templates/install.sh.tftpl
+++ b/modules/azure/custom-data/templates/install.sh.tftpl
@@ -32,7 +32,9 @@ else
   DD_API_KEY=$api_key
 fi
 
-DD_HOSTNAME="$(hostname)"
+# Append the last 6 bytes of the VM UUID to prevent hostname collisions
+VM_ID=$(cat /sys/devices/virtual/dmi/id/product_uuid)
+DD_HOSTNAME="$(hostname)-$${VM_ID:(-12)}"
 DD_SITE="${site}"
 DD_AGENTLESS_VERSION="${scanner_version}"
 DD_AGENTLESS_CHANNEL="${scanner_channel}"


### PR DESCRIPTION
Append the last 6 bytes of the VM UUID to prevent hostname collisions.