### PR TITLE
Azure: use Rich Health States

### DIFF
--- a/modules/azure/virtual-machine/main.tf
+++ b/modules/azure/virtual-machine/main.tf
@@ -61,13 +61,14 @@ resource "azurerm_linux_virtual_machine_scale_set" "vmss" {
     name                 = "HealthExtension"
     publisher            = "Microsoft.ManagedServices"
     type                 = "ApplicationHealthLinux"
-    type_handler_version = "1.0"
+    type_handler_version = "2.0"
     settings = jsonencode({
       protocol          = "http",
       port              = 6253,
       requestPath       = "/health"
       intervalInSeconds = 10
       numberOfProbes    = 3
+      gracePeriod       = 1200
     })
   }
 }


### PR DESCRIPTION
This gives the VM additional time to initialize.

Supported since scanner version 0.11.6.