### PR TITLE
Azure: declare minimum provider versions only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: terraform-docs-go
         name: terraform docs for the AWS root module
-        args: ["markdown", "table", "--output-file", "README.md", "./"]
+        args: ["markdown", "table", "--lockfile=false", "--output-file", "README.md", "./"]
       - id: terraform-docs-go
         name: terraform docs for the 'instance' module
         args: ["markdown", "table", "--output-file", "README.md", "./modules/instance"]
@@ -22,7 +22,7 @@ repos:
         args: ["markdown", "table", "--output-file", "README.md", "./modules/vpc"]
       - id: terraform-docs-go
         name: terraform docs for the Azure root module
-        args: ["markdown", "table", "--output-file", "README.md", "./modules/azure"]
+        args: ["markdown", "table", "--lockfile=false", "--output-file", "README.md", "./modules/azure"]
       - id: terraform-docs-go
         name: terraform docs for the 'azure/custom-data' module
         args: ["markdown", "table", "--output-file", "README.md", "./modules/azure/custom-data"]

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -4,15 +4,15 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | 1.13.1 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.101.0 |
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >= 1.13.1 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.101.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | 1.13.1 |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.101.0 |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 1.13.1 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.101.0 |
 
 ## Modules
 
@@ -29,10 +29,10 @@
 
 | Name | Type |
 |------|------|
-| [azapi_resource_id.api_key_id](https://registry.terraform.io/providers/Azure/azapi/1.13.1/docs/data-sources/resource_id) | data source |
-| [azapi_resource_id.key_vault_id](https://registry.terraform.io/providers/Azure/azapi/1.13.1/docs/data-sources/resource_id) | data source |
-| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/data-sources/key_vault) | data source |
-| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/data-sources/subscription) | data source |
+| [azapi_resource_id.api_key_id](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_id) | data source |
+| [azapi_resource_id.key_vault_id](https://registry.terraform.io/providers/Azure/azapi/latest/docs/data-sources/resource_id) | data source |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs
 

--- a/modules/azure/managed-identity/README.md
+++ b/modules/azure/managed-identity/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.101.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.101.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.101.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.101.0 |
 
 ## Modules
 
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_user_assigned_identity.identity](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
 
 ## Inputs
 

--- a/modules/azure/managed-identity/provider.tf
+++ b/modules/azure/managed-identity/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.101.0"
+      version = ">= 3.101.0"
     }
   }
 }

--- a/modules/azure/provider.tf
+++ b/modules/azure/provider.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     azapi = {
       source  = "Azure/azapi"
-      version = "1.13.1"
+      version = ">= 1.13.1"
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.101.0"
+      version = ">= 3.101.0"
     }
   }
 }

--- a/modules/azure/resource-group/README.md
+++ b/modules/azure/resource-group/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.101.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.101.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.101.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.101.0 |
 
 ## Modules
 
@@ -20,7 +20,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_resource_group.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/resource_group) | resource |
+| [azurerm_resource_group.resource_group](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
 
 ## Inputs
 

--- a/modules/azure/resource-group/provider.tf
+++ b/modules/azure/resource-group/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.101.0"
+      version = ">= 3.101.0"
     }
   }
 }

--- a/modules/azure/roles/README.md
+++ b/modules/azure/roles/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.101.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.101.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.101.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.101.0 |
 
 ## Modules
 
@@ -20,11 +20,11 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_role_assignment.api_key_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.orchestrator_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.worker_role_assignments](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/role_assignment) | resource |
-| [azurerm_role_definition.orchestrator_role](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/role_definition) | resource |
-| [azurerm_role_definition.worker_role](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/role_definition) | resource |
+| [azurerm_role_assignment.api_key_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.orchestrator_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.worker_role_assignments](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.orchestrator_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_role_definition.worker_role](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
 
 ## Inputs
 

--- a/modules/azure/roles/provider.tf
+++ b/modules/azure/roles/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.101.0"
+      version = ">= 3.101.0"
     }
   }
 }

--- a/modules/azure/virtual-machine/README.md
+++ b/modules/azure/virtual-machine/README.md
@@ -4,14 +4,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.101.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.101.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.101.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.101.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
@@ -22,8 +22,8 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_linux_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/linux_virtual_machine_scale_set) | resource |
-| [azurerm_monitor_autoscale_setting.autoscale_setting](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/monitor_autoscale_setting) | resource |
+| [azurerm_linux_virtual_machine_scale_set.vmss](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_virtual_machine_scale_set) | resource |
+| [azurerm_monitor_autoscale_setting.autoscale_setting](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_autoscale_setting) | resource |
 | [random_integer.restart_minute](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) | resource |
 
 ## Inputs

--- a/modules/azure/virtual-machine/provider.tf
+++ b/modules/azure/virtual-machine/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.101.0"
+      version = ">= 3.101.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/azure/virtual-network/README.md
+++ b/modules/azure/virtual-network/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | 3.101.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >= 3.101.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | 3.101.0 |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >= 3.101.0 |
 
 ## Modules
 
@@ -20,15 +20,15 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_bastion_host.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/bastion_host) | resource |
-| [azurerm_nat_gateway.natgw](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/nat_gateway) | resource |
-| [azurerm_nat_gateway_public_ip_association.natgw_ip_assoc](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/nat_gateway_public_ip_association) | resource |
-| [azurerm_public_ip.bastion_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/public_ip) | resource |
-| [azurerm_public_ip.natgw_ip](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/public_ip) | resource |
-| [azurerm_subnet.bastion_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/subnet) | resource |
-| [azurerm_subnet.default_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/subnet) | resource |
-| [azurerm_subnet_nat_gateway_association.subnet_natgw_assoc](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/subnet_nat_gateway_association) | resource |
-| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/3.101.0/docs/resources/virtual_network) | resource |
+| [azurerm_bastion_host.bastion](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/bastion_host) | resource |
+| [azurerm_nat_gateway.natgw](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway) | resource |
+| [azurerm_nat_gateway_public_ip_association.natgw_ip_assoc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/nat_gateway_public_ip_association) | resource |
+| [azurerm_public_ip.bastion_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_public_ip.natgw_ip](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_subnet.bastion_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.default_subnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet_nat_gateway_association.subnet_natgw_assoc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet_nat_gateway_association) | resource |
+| [azurerm_virtual_network.vnet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
 
 ## Inputs
 

--- a/modules/azure/virtual-network/provider.tf
+++ b/modules/azure/virtual-network/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.101.0"
+      version = ">= 3.101.0"
     }
   }
 }


### PR DESCRIPTION
According to the [Terraform documentation](https://developer.hashicorp.com/terraform/language/expressions/version-constraints#terraform-core-and-provider-versions):

> - Reusable modules should constrain only their minimum allowed versions of Terraform and providers, such as >= 0.12.0. This helps avoid known incompatibilities, while allowing the user of the module flexibility to upgrade to newer versions of Terraform without altering the module.
> - Root modules should use a ~> constraint to set both a lower and upper bound on versions for each provider they depend on.

The main module can be used as either a root module or a child module, so I opted to set only a minimum version there too.