### PR TITLE
Azure: additional configuration options in main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ No resources.
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
 | <a name="input_enable_ssm_vpc_endpoint"></a> [enable\_ssm\_vpc\_endpoint](#input\_enable\_ssm\_vpc\_endpoint) | Whether to enable AWS SSM VPC endpoint (only applicable if enable\_ssm is true) | `bool` | `true` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | Name of the instance profile to attach to the instance | `string` | n/a | yes |
-| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta) | `string` | `"stable"` | no |
+| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta). | `string` | `"stable"` | no |
 | <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `null` | no |

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -39,6 +39,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_ssh_key"></a> [admin\_ssh\_key](#input\_admin\_ssh\_key) | SSH public key of the admin user. | `string` | n/a | yes |
+| <a name="input_agent_configuration"></a> [agent\_configuration](#input\_agent\_configuration) | Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. | `any` | `{}` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Agentless Scanner to submit vulnerabilities to Datadog. | `string` | `null` | no |
 | <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | The versionless resource ID of the Azure Key Vault secret holding the Datadog API key. Ignored if api\_key is specified. | `string` | `null` | no |
 | <a name="input_bastion"></a> [bastion](#input\_bastion) | Create a bastion in the subnet. | `bool` | `false` | no |
@@ -46,6 +47,9 @@
 | <a name="input_location"></a> [location](#input\_location) | The location where the Datadog Agentless Scanner resources will be created. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where the Datadog Agentless Scanner resources will be created. | `string` | n/a | yes |
 | <a name="input_scan_scopes"></a> [scan\_scopes](#input\_scan\_scopes) | The set of scopes that the Datadog Agentless Scanner is allowed to scan. Defaults to the current subscription. | `list(string)` | `[]` | no |
+| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta) | `string` | `"stable"` | no |
+| <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the resources created. | `map(string)` | `{}` | no |
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -47,7 +47,7 @@
 | <a name="input_location"></a> [location](#input\_location) | The location where the Datadog Agentless Scanner resources will be created. | `string` | n/a | yes |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | The name of the resource group where the Datadog Agentless Scanner resources will be created. | `string` | n/a | yes |
 | <a name="input_scan_scopes"></a> [scan\_scopes](#input\_scan\_scopes) | The set of scopes that the Datadog Agentless Scanner is allowed to scan. Defaults to the current subscription. | `list(string)` | `[]` | no |
-| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta) | `string` | `"stable"` | no |
+| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta). | `string` | `"stable"` | no |
 | <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `null` | no |

--- a/modules/azure/custom-data/README.md
+++ b/modules/azure/custom-data/README.md
@@ -28,7 +28,6 @@ No modules.
 | <a name="input_agent_configuration"></a> [agent\_configuration](#input\_agent\_configuration) | Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. | `any` | `{}` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | n/a | yes |
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | Client ID of the managed identity used by the Datadog Agentless Scanner | `string` | n/a | yes |
-| <a name="input_location"></a> [location](#input\_location) | The location of the resource group where the Datadog Agentless Scanner resources will be created | `string` | n/a | yes |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Specifies the channel to use for installing the scanner | `string` | `"stable"` | no |
 | <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the version of the scanner to install | `string` | `"0.11"` | no |

--- a/modules/azure/custom-data/main.tf
+++ b/modules/azure/custom-data/main.tf
@@ -7,6 +7,5 @@ resource "terraform_data" "template" {
     scanner_channel       = var.scanner_channel,
     scanner_configuration = var.scanner_configuration,
     agent_configuration   = var.agent_configuration,
-    region                = var.location,
   })
 }

--- a/modules/azure/custom-data/variables.tf
+++ b/modules/azure/custom-data/variables.tf
@@ -1,8 +1,3 @@
-variable "location" {
-  description = "The location of the resource group where the Datadog Agentless Scanner resources will be created"
-  type        = string
-}
-
 variable "api_key" {
   description = "Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog"
   sensitive   = true

--- a/modules/azure/main.tf
+++ b/modules/azure/main.tf
@@ -39,7 +39,6 @@ module "virtual_network" {
 
 module "custom_data" {
   source    = "./custom-data"
-  location  = var.location
   api_key   = var.api_key != null ? var.api_key : "@Microsoft.KeyVault(SecretUri=${local.api_key_uri})"
   site      = var.site
   client_id = module.managed_identity.identity.client_id

--- a/modules/azure/main.tf
+++ b/modules/azure/main.tf
@@ -38,10 +38,14 @@ module "virtual_network" {
 }
 
 module "custom_data" {
-  source    = "./custom-data"
-  api_key   = var.api_key != null ? var.api_key : "@Microsoft.KeyVault(SecretUri=${local.api_key_uri})"
-  site      = var.site
-  client_id = module.managed_identity.identity.client_id
+  source                = "./custom-data"
+  api_key               = var.api_key != null ? var.api_key : "@Microsoft.KeyVault(SecretUri=${local.api_key_uri})"
+  scanner_channel       = var.scanner_channel
+  scanner_version       = var.scanner_version
+  scanner_configuration = var.scanner_configuration
+  agent_configuration   = var.agent_configuration
+  site                  = var.site
+  client_id             = module.managed_identity.identity.client_id
 }
 
 module "managed_identity" {

--- a/modules/azure/variables.tf
+++ b/modules/azure/variables.tf
@@ -72,7 +72,7 @@ variable "scanner_version" {
 }
 
 variable "scanner_channel" {
-  description = "Channel of the scanner to install from (stable or beta)"
+  description = "Channel of the scanner to install from (stable or beta)."
   type        = string
   default     = "stable"
   validation {

--- a/modules/azure/variables.tf
+++ b/modules/azure/variables.tf
@@ -60,3 +60,35 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "scanner_version" {
+  description = "Version of the scanner to install"
+  type        = string
+  default     = "0.11"
+  validation {
+    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.scanner_version))
+    error_message = "The scanner version must be in the format of X.Y"
+  }
+}
+
+variable "scanner_channel" {
+  description = "Channel of the scanner to install from (stable or beta)"
+  type        = string
+  default     = "stable"
+  validation {
+    condition     = contains(["stable", "beta"], var.scanner_channel)
+    error_message = "The scanner channel must be either 'stable' or 'beta'"
+  }
+}
+
+variable "scanner_configuration" {
+  description = "Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner."
+  type        = any
+  default     = {}
+}
+
+variable "agent_configuration" {
+  description = "Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent."
+  type        = any
+  default     = {}
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "scanner_version" {
 }
 
 variable "scanner_channel" {
-  description = "Channel of the scanner to install from (stable or beta)"
+  description = "Channel of the scanner to install from (stable or beta)."
   type        = string
   default     = "stable"
   validation {


### PR DESCRIPTION
Pass more options to custom-data:
  - scanner_channel
  - scanner_version
  - scanner_configuration
  - agent_configuration