### PR TITLE
Install semgrep

### DIFF
--- a/modules/azure/CHANGELOG.md
+++ b/modules/azure/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version TBD
 
+- Install semgrep dependency
 - Fix constant Terraform drift when multiple scan scopes are specified
 - Split off role definition and assignment into a separate module
 - Upgrade scanner instances to Ubuntu Server 24.04

--- a/modules/azure/custom-data/templates/install.sh.tftpl
+++ b/modules/azure/custom-data/templates/install.sh.tftpl
@@ -17,6 +17,7 @@ echo "nbd" > /etc/modules-load.d/nbd.conf
 echo "options nbd nbds_max=128" > /etc/modprobe.d/nbd.conf
 
 # Install requirements
+snap install --no-wait semgrep
 apt update
 apt install -y nbd-client
 

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -17,6 +17,7 @@ echo "nbd" > /etc/modules-load.d/nbd.conf
 echo "options nbd nbds_max=128" > /etc/modprobe.d/nbd.conf
 
 # Install requirements
+snap install --no-wait semgrep
 apt update
 apt install -y nbd-client curl jq
 


### PR DESCRIPTION
There is no `deb` package for `semgrep`, so the options are to install it using `snap` or `pip`.

`pip` is not installed by default in Ubuntu Server and depends on `build-essential`, so a `snap` install is definitely going to be faster.

I used the `--no-wait` flag to install it in the background. Otherwise it takes around 20 seconds (tested on an Azure [Standard_B2ps_v2](https://learn.microsoft.com/azure/virtual-machines/sizes/general-purpose/bpsv2-series)).