### PR TITLE
Add permission to copy ami

### DIFF
--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -149,8 +149,8 @@ data "aws_iam_policy_document" "scanning_orchestrator_policy_document" {
       "arn:${data.aws_partition.current.partition}:ec2:*:*:image/*",
     ]
 
-    // Enforce that any of these actions can be performed on resources
-    // images that have the DatadogAgentlessScanner tag.
+    // Enforce that any of these actions can be performed on images
+    // that have the DatadogAgentlessScanner tag.
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/DatadogAgentlessScanner"

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -123,6 +123,7 @@ data "aws_iam_policy_document" "scanning_orchestrator_policy_document" {
     ]
     resources = [
       "arn:${data.aws_partition.current.partition}:ec2:*:*:image/*",
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:snapshot/*",
     ]
     // Enforcing created image has DatadogAgentlessScanner tag
     condition {
@@ -178,6 +179,19 @@ data "aws_iam_policy_document" "scanning_orchestrator_policy_document" {
       // Required to be able to wait for volumes completion and cleanup. It
       // cannot be restricted.
       "ec2:DescribeVolumes",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+
+  statement {
+    sid    = "DatadogAgentlessScannerDescribeImages"
+    effect = "Allow"
+    actions = [
+      // Required to be able to wait for image completion and cleanup. It
+      // cannot be restricted.
+      "ec2:DescribeImages",
     ]
     resources = [
       "*",


### PR DESCRIPTION
This PR add the following permission:
* to tag AMI when making a copy
* to make a copy of any ami
* to deregister the copy created

This is needed in order to scan ami that are shared with the scanned account.
The AMI can be used and copied but the underlying snapshot might not be.

See scanner changes here: https://github.com/DataDog/datadog-agentless-scanner/pull/96/files 