### PR TITLE
Allow scanning volumes with customer-managed-key

### DIFF
--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -205,7 +205,7 @@ data "aws_iam_policy_document" "scanning_orchestrator_policy_document" {
     resources = ["arn:${data.aws_partition.current.partition}:kms:*:*:key/*"]
 
     // The following conditions enforce that decrypt action
-    // can only be performed on snapshots from calls by ebs API.
+    // can only be performed from calls by ebs API.
     condition {
       test     = "ForAnyValue:StringEquals"
       variable = "kms:EncryptionContextKeys"
@@ -372,7 +372,7 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
     resources = ["arn:${data.aws_partition.current.partition}:kms:*:*:key/*"]
 
     // The following conditions enforce that decrypt action
-    // can only be performed on snapshots from calls by ebs API.
+    // can only be performed from calls by ebs API.
     condition {
       test     = "ForAnyValue:StringEquals"
       variable = "kms:EncryptionContextKeys"

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -214,12 +214,6 @@ data "aws_iam_policy_document" "scanning_orchestrator_policy_document" {
 
     condition {
       test     = "StringLike"
-      variable = "kms:EncryptionContext:aws:ebs:id"
-      values   = ["snap-*"]
-    }
-
-    condition {
-      test     = "StringLike"
       variable = "kms:ViaService"
       values   = ["ec2.*.amazonaws.com"]
     }
@@ -383,12 +377,6 @@ data "aws_iam_policy_document" "scanning_worker_policy_document" {
       test     = "ForAnyValue:StringEquals"
       variable = "kms:EncryptionContextKeys"
       values   = ["aws:ebs:id"]
-    }
-
-    condition {
-      test     = "StringLike"
-      variable = "kms:EncryptionContext:aws:ebs:id"
-      values   = ["snap-*"]
     }
 
     condition {


### PR DESCRIPTION
We need to be able to read and copy from snapshots originating from CreateSnapshot. When reaching for these snapshots the `kms:EncryptionContext` for key `aws:ebs:id` is the originating volume.

reference: https://github.com/awsdocs/aws-kms-developer-guide/blob/master/doc_source/services-ebs.md#amazon-ebs-encryption-context