### PR TITLE
Allow specificy ASG parameters instance_type and instance_count from main module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.11.4
+
+- Add parameters `instance_type` and `instance_count` to configure the auto-scaling group properties
+
 ## Version 0.11.3
 
 - Add permissions to copy AMIs (ec2:CopyImage) to improve coverage of cross-account AMI scanning

--- a/README.md
+++ b/README.md
@@ -122,7 +122,9 @@ No resources.
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
 | <a name="input_enable_ssm_vpc_endpoint"></a> [enable\_ssm\_vpc\_endpoint](#input\_enable\_ssm\_vpc\_endpoint) | Whether to enable AWS SSM VPC endpoint (only applicable if enable\_ssm is true) | `bool` | `true` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Size of the autoscaling group the instance is in (i.e. number of instances with scanners to run) | `number` | `1` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | Name of the instance profile to attach to the instance | `string` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance running the scanner | `string` | `"t4g.large"` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta). | `string` | `"stable"` | no |
 | <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Version of the scanner to install | `string` | `"0.11"` | no |

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,8 @@ module "instance" {
   subnet_ids           = [for s in module.vpc.private_subnets : s.id]
   iam_instance_profile = var.instance_profile_name
   tags                 = var.tags
+  instance_type        = var.instance_type
+  asg_size             = var.instance_count
 
   depends_on = [module.vpc.routing_ready]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -71,3 +71,15 @@ variable "agent_configuration" {
   type        = any
   default     = {}
 }
+
+variable "instance_type" {
+  description = "The type of instance running the scanner"
+  type        = string
+  default     = "t4g.large"
+}
+
+variable "instance_count" {
+  description = "Size of the autoscaling group the instance is in (i.e. number of instances with scanners to run)"
+  type        = number
+  default     = 1
+}


### PR DESCRIPTION
Adding `instance_type` and `instance_count` variables for AWS main module to allow configuring the ASG.