### PR TITLE
docs: add example of extended agent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent_configuration"></a> [agent\_configuration](#input\_agent\_configuration) | Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. | `any` | `{}` | no |
+| <a name="input_agent_configuration"></a> [agent\_configuration](#input\_agent\_configuration) | Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. For more details: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/. Warning: this is an advanced feature and can break the Datadog Agent if not used correctly. | `any` | `{}` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API keys required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | `null` | no |
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
@@ -178,7 +178,7 @@ No resources.
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | Name of the instance profile to attach to the instance | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance running the scanner | `string` | `"t4g.large"` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta). | `string` | `"stable"` | no |
-| <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
+| <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly. | `any` | `{}` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |

--- a/examples/custom_agent_configurations/README.md
+++ b/examples/custom_agent_configurations/README.md
@@ -1,0 +1,5 @@
+# Custom Agent Configurations Examples
+
+This example provides some configuration examples extending the agent
+configuration with options provided through terraform.
+

--- a/examples/custom_agent_configurations/main.tf
+++ b/examples/custom_agent_configurations/main.tf
@@ -1,0 +1,74 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "scanner_role" {
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.3"
+
+  account_roles       = [module.delegate_role.role.arn]
+  api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
+}
+
+module "delegate_role" {
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.3"
+
+  scanner_roles = [module.scanner_role.role.arn]
+}
+
+module "agentless_scanner" {
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.3"
+
+  api_key               = var.api_key
+  instance_profile_name = module.scanner_role.instance_profile.name
+
+  # It is possible to provide any agent configuration from this parameter.
+  # The given HCL structure is encoded in YAML and used as configuration for the Datadog Agent.
+  # They should respect the configuration schema of the Agent that is described here: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml
+  agent_configuration = {
+    # Providing specific tags for the scanner instance
+    tags = [
+      "env:staging",
+      "foo:bar",
+    ],
+
+    # Providing additional_endpoints for dual shipping of metrics
+    # https://docs.datadoghq.com/agent/configuration/dual-shipping/
+    additional_endpoints = {
+      "https://app.datadoghq.com" = [
+        "ENC[arn:aws:secretsmanager:us-east-1:734986933288:secret:scanner/api_key_ddstaging]"
+      ]
+    }
+
+    # Providing additional_endpoints for dual shipping of logs
+    # https://docs.datadoghq.com/agent/configuration/dual-shipping/
+    logs_config = {
+      additional_endpoints = [
+        {
+          api_key = "ENC[arn:aws:secretsmanager:us-east-1:734986933288:secret:scanner/api_key_ddstaging]"
+          host    = "ddstaging-http-intake.logs.datadoghq.com."
+        }
+      ]
+    }
+  }
+
+  scanner_configuration = {
+    # Providing dual shipping of SBOMs
+    sbom_additional_endpoints = [
+      {
+        api_key = "ENC[arn:aws:secretsmanager:us-east-1:xxxx:secret:xxxx]"
+        Host    = "sbom-intake.datadoghq.com"
+      }
+    ]
+  }
+}

--- a/examples/custom_agent_configurations/variables.tf
+++ b/examples/custom_agent_configurations/variables.tf
@@ -1,0 +1,4 @@
+variable "api_key" {
+  description = "Specifies the API keys required by the Datadog Agent to submit vulnerabilities to Datadog"
+  type        = string
+}

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -36,11 +36,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_agent_configuration"></a> [agent\_configuration](#input\_agent\_configuration) | Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. | `any` | `{}` | no |
+| <a name="input_agent_configuration"></a> [agent\_configuration](#input\_agent\_configuration) | Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. For more details: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/. Warning: this is an advanced feature and can break the Datadog Agent if not used correctly. | `any` | `{}` | no |
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Specifies the API key required by the Datadog Agent to submit vulnerabilities to Datadog | `string` | `null` | no |
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Specifies the channel to use for installing the scanner | `string` | `"stable"` | no |
-| <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. | `any` | `{}` | no |
+| <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly. | `any` | `{}` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources | `map(string)` | `{}` | no |

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -26,15 +26,31 @@ variable "scanner_channel" {
 }
 
 variable "scanner_configuration" {
-  description = "Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner."
+  description = "Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly."
   type        = any
   default     = {}
+  validation {
+    condition     = can(yamlencode(var.scanner_configuration))
+    error_message = "The scanner_configuration variable cannot be properly encoded to YAML"
+  }
+  validation {
+    condition     = !contains(keys(var.scanner_configuration), "api_key") && !contains(keys(var.scanner_configuration), "hostname") && !contains(keys(var.scanner_configuration), "site")
+    error_message = "The scanner_configuration cannot override the 'api_key', 'hostname', or 'site' fields."
+  }
 }
 
 variable "agent_configuration" {
-  description = "Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent."
+  description = "Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. For more details: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/. Warning: this is an advanced feature and can break the Datadog Agent if not used correctly."
   type        = any
   default     = {}
+  validation {
+    condition     = can(yamlencode(var.agent_configuration))
+    error_message = "The agent_configuration variable cannot be properly encoded to YAML"
+  }
+  validation {
+    condition     = !contains(keys(var.agent_configuration), "api_key") && !contains(keys(var.agent_configuration), "hostname") && !contains(keys(var.agent_configuration), "site") && !contains(keys(var.agent_configuration), "logs_enabled") && !contains(keys(var.agent_configuration), "ec2_prefer_imdsv2")
+    error_message = "The agent_configuration cannot override the 'api_key', 'hostname', or 'site' fields."
+  }
 }
 
 variable "api_key_secret_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -61,13 +61,13 @@ variable "tags" {
 }
 
 variable "scanner_configuration" {
-  description = "Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner."
+  description = "Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly."
   type        = any
   default     = {}
 }
 
 variable "agent_configuration" {
-  description = "Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent."
+  description = "Specifies a custom configuration for the Datadog Agent. The specified object is passed directly as a configuration input for the Datadog Agent. For more details: https://docs.datadoghq.com/agent/configuration/agent-configuration-files/. Warning: this is an advanced feature and can break the Datadog Agent if not used correctly."
   type        = any
   default     = {}
 }


### PR DESCRIPTION
This PR adds examples to provide extended configurations for the agent.

It also adds conditions on the provided agent_configuration to make sure certain fields cannot be overriden (api_key, hostname, site etc.)