### PR TITLE
Scanner role delegations based on a account_id wildcard by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version TBD
+
+- Scanner role delegations based on a account_id wildcard by default
+
 ## Version 0.11.4
 
 - Add parameters `instance_type` and `instance_count` to configure the auto-scaling group properties

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Before using this module, make sure you have the following:
 To use this module in your Terraform configuration, add the following code in your existing Terraform code:
 
 ```hcl
-# First we need to define the proper roles for our scanners. It consists of two different modules that have a two way bindings between them.
+# First we need to define the proper roles for our scanners. It consists of two different modules.
 
 # 1. The "scanning delegate role" defines all the policies and IAM roles necessary for the scanner to interact and scan some specific account resources.
 # It shall be created for every account that the agentless scanner will be able scan. These roles are meant to be assumed by the "agentless scanner role".
@@ -29,13 +29,8 @@ module "delegate_role" {
 module "scanner_role" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role"
 
-  account_roles       = [module.delegate_role.role.arn]
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
-
-# As you can see there is a two way binding between these two "role" modules.
-# - the scanner role requires the list of delegate role ARNs for the scanner to assume.
-# - the delegate role(s) require the scanner role ARN as input in order to define the trust relationship between the EC2 scanner role and the delegate role to be assumed.
 
 # Finally we can create the agentless scanner instance. It requires the instance profile name that was created by the scanner_role.
 # This module will define the VPC, subnets, network and compute resources required for the agentless scanner.

--- a/examples/cross_account/README.md
+++ b/examples/cross_account/README.md
@@ -14,7 +14,6 @@ To deploy a Datadog Agentless scanner:
 1. Run `terraform init`.
 1. Run `terraform apply`.
 1. Set your Datadog [API key](https://docs.datadoghq.com/account_management/api-app-keys/).
-1. You can leave the `cross_account_delegate_arn` variable empty.
 1. Run `terraform output scanner_role` and copy that ARN.
 
 To deploy the delegate role:

--- a/examples/cross_account/scanner_account/main.tf
+++ b/examples/cross_account/scanner_account/main.tf
@@ -16,11 +16,6 @@ provider "aws" {
 module "scanner_role" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.4"
 
-  # compact remove empty value for cross_account_delegate_arn during the first run
-  account_roles = compact([
-    module.self_delegate_role.role.arn,
-    var.cross_account_delegate_arn
-  ])
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 

--- a/examples/cross_account/scanner_account/variables.tf
+++ b/examples/cross_account/scanner_account/variables.tf
@@ -2,8 +2,3 @@ variable "api_key" {
   description = "Specifies the API keys required by the Datadog Agent to submit vulnerabilities to Datadog"
   type        = string
 }
-
-variable "cross_account_delegate_arn" {
-  description = "Specifies the ARN of the delegate role created for cross account scanning"
-  type        = string
-}

--- a/examples/custom_agent_configurations/main.tf
+++ b/examples/custom_agent_configurations/main.tf
@@ -16,7 +16,6 @@ provider "aws" {
 module "scanner_role" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.3"
 
-  account_roles       = [module.delegate_role.role.arn]
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 

--- a/examples/custom_vpc/main.tf
+++ b/examples/custom_vpc/main.tf
@@ -15,8 +15,6 @@ provider "aws" {
 
 module "agentless_scanner_role" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.6.0"
-
-  account_roles = [module.delegate_role.role.arn]
 }
 
 module "delegate_role" {

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -22,7 +22,6 @@ provider "aws" {
 module "agentless_scanner_role" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.4"
 
-  account_roles = [module.delegate_role.role.arn]
   api_key_secret_arns = [
     module.agentless_scanner_us.api_key_secret_arn,
     module.agentless_scanner_eu.api_key_secret_arn,

--- a/examples/single_region/main.tf
+++ b/examples/single_region/main.tf
@@ -16,7 +16,6 @@ provider "aws" {
 module "scanner_role" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.4"
 
-  account_roles       = [module.delegate_role.role.arn]
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 

--- a/modules/agentless-scanner-role/README.md
+++ b/modules/agentless-scanner-role/README.md
@@ -40,6 +40,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless scanner can assume - make sure to respect the same naming convention as the agentless scanner role. | `list(string)` | <pre>[<br>  "arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole"<br>]</pre> | no |
+| <a name="input_allowed_organizational_unit_ids"></a> [allowed\_organizational\_unit\_ids](#input\_allowed\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) that are allowed to assume the Datadog agentless scanner role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_api_key_secret_arns"></a> [api\_key\_secret\_arns](#input\_api\_key\_secret\_arns) | List of ARNs of the secrets holding the Datadog API keys | `list(string)` | n/a | yes |
 | <a name="input_api_key_secret_kms_key_arns"></a> [api\_key\_secret\_kms\_key\_arns](#input\_api\_key\_secret\_kms\_key\_arns) | List of ARNs of the KMS keys encrypting the secrets | `list(string)` | `[]` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
@@ -47,7 +48,6 @@ No modules.
 | <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | IAM policy path | `string` | `null` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerAgentRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role path | `string` | `"/"` | no |
-| <a name="input_organization_unit_ids"></a> [organization\_unit\_ids](#input\_organization\_unit\_ids) | List of AWS Organization Unit IDs that are allowed to assume the Datadog agentless scanner role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/agentless-scanner-role/README.md
+++ b/modules/agentless-scanner-role/README.md
@@ -39,7 +39,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless scanner can assume | `list(string)` | `[]` | no |
+| <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless scanner can assume - make sure to respect the same naming convention as the agentless scanner role. | `list(string)` | <pre>[<br>  "arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole"<br>]</pre> | no |
 | <a name="input_api_key_secret_arns"></a> [api\_key\_secret\_arns](#input\_api\_key\_secret\_arns) | List of ARNs of the secrets holding the Datadog API keys | `list(string)` | n/a | yes |
 | <a name="input_api_key_secret_kms_key_arns"></a> [api\_key\_secret\_kms\_key\_arns](#input\_api\_key\_secret\_kms\_key\_arns) | List of ARNs of the KMS keys encrypting the secrets | `list(string)` | `[]` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
@@ -47,6 +47,7 @@ No modules.
 | <a name="input_iam_policy_path"></a> [iam\_policy\_path](#input\_iam\_policy\_path) | IAM policy path | `string` | `null` | no |
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerAgentRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role path | `string` | `"/"` | no |
+| <a name="input_organization_unit_ids"></a> [organization\_unit\_ids](#input\_organization\_unit\_ids) | List of AWS Organization Unit IDs that are allowed to assume the Datadog agentless scanner role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/agentless-scanner-role/main.tf
+++ b/modules/agentless-scanner-role/main.tf
@@ -53,15 +53,9 @@ data "aws_iam_policy_document" "scanner_policy_document" {
     resources = var.account_roles
 
     condition {
-      test     = "StringEquals"
-      variable = "iam:ResourceTag/DatadogAgentlessScanner"
-      values   = ["true"]
-    }
-
-    condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgID"
-      values   = var.organization_unit_ids
+      values   = var.allowed_organizational_unit_ids
     }
   }
 

--- a/modules/agentless-scanner-role/main.tf
+++ b/modules/agentless-scanner-role/main.tf
@@ -51,6 +51,18 @@ data "aws_iam_policy_document" "scanner_policy_document" {
     effect    = "Allow"
     actions   = ["sts:AssumeRole"]
     resources = var.account_roles
+
+    condition {
+      test     = "StringEquals"
+      variable = "iam:ResourceTag/DatadogAgentlessScanner"
+      values   = ["true"]
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgID"
+      values   = var.organization_unit_ids
+    }
   }
 
   statement {

--- a/modules/agentless-scanner-role/variables.tf
+++ b/modules/agentless-scanner-role/variables.tf
@@ -4,8 +4,8 @@ variable "iam_role_name" {
   default     = "DatadogAgentlessScannerAgentRole"
 }
 
-variable "organization_unit_ids" {
-  description = "List of AWS Organization Unit IDs that are allowed to assume the Datadog agentless scanner role"
+variable "allowed_organizational_unit_ids" {
+  description = "List of AWS Organizations organizational units (OUs) that are allowed to assume the Datadog agentless scanner role"
   type        = list(string)
   default     = ["*"]
 }

--- a/modules/agentless-scanner-role/variables.tf
+++ b/modules/agentless-scanner-role/variables.tf
@@ -4,6 +4,12 @@ variable "iam_role_name" {
   default     = "DatadogAgentlessScannerAgentRole"
 }
 
+variable "organization_unit_ids" {
+  description = "List of AWS Organization Unit IDs that are allowed to assume the Datadog agentless scanner role"
+  type        = list(string)
+  default     = ["*"]
+}
+
 variable "iam_policy_name" {
   description = "Name to use on IAM policy created"
   type        = string
@@ -23,9 +29,9 @@ variable "iam_policy_path" {
 }
 
 variable "account_roles" {
-  description = "List of cross accounts roles ARN that the Datadog agentless scanner can assume"
+  description = "List of cross accounts roles ARN that the Datadog agentless scanner can assume - make sure to respect the same naming convention as the agentless scanner role."
   type        = list(string)
-  default     = []
+  default     = ["arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole"]
 }
 
 variable "api_key_secret_arns" {

--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -45,6 +45,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerDelegateRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role and policies path | `string` | `"/"` | no |
+| <a name="input_scanner_organization_unit_ids"></a> [scanner\_organization\_unit\_ids](#input\_scanner\_organization\_unit\_ids) | List of organization unit IDs allowed to assume this role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_scanner_roles"></a> [scanner\_roles](#input\_scanner\_roles) | List of roles ARN allowed to assume this role | `list(string)` | n/a | yes |
 | <a name="input_sensitive_data_scanning_enabled"></a> [sensitive\_data\_scanning\_enabled](#input\_sensitive\_data\_scanning\_enabled) | Installs specific permissions to enable scanning of datastores (S3 buckets and RDS instances) | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |

--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -45,7 +45,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerDelegateRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role and policies path | `string` | `"/"` | no |
-| <a name="input_scanner_organization_unit_ids"></a> [scanner\_organization\_unit\_ids](#input\_scanner\_organization\_unit\_ids) | List of organization unit IDs allowed to assume this role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_scanner_organizational_unit_ids"></a> [scanner\_organizational\_unit\_ids](#input\_scanner\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) allowed to assume this role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_scanner_roles"></a> [scanner\_roles](#input\_scanner\_roles) | List of roles ARN allowed to assume this role | `list(string)` | n/a | yes |
 | <a name="input_sensitive_data_scanning_enabled"></a> [sensitive\_data\_scanning\_enabled](#input\_sensitive\_data\_scanning\_enabled) | Installs specific permissions to enable scanning of datastores (S3 buckets and RDS instances) | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -499,9 +499,21 @@ data "aws_iam_policy_document" "assume_role_policy" {
     }
 
     condition {
+      test     = "StringEquals"
+      variable = "iam:ResourceTag/DatadogAgentlessScanner"
+      values   = ["true"]
+    }
+
+    condition {
       test     = "ArnLike"
       variable = "aws:PrincipalArn"
       values   = var.scanner_roles
+    }
+
+    condition {
+      test     = "ForAnyValue:StringLike"
+      variable = "aws:PrincipalOrgID"
+      values   = var.scanner_organization_unit_ids
     }
   }
 }

--- a/modules/scanning-delegate-role/main.tf
+++ b/modules/scanning-delegate-role/main.tf
@@ -513,7 +513,7 @@ data "aws_iam_policy_document" "assume_role_policy" {
     condition {
       test     = "ForAnyValue:StringLike"
       variable = "aws:PrincipalOrgID"
-      values   = var.scanner_organization_unit_ids
+      values   = var.scanner_organizational_unit_ids
     }
   }
 }

--- a/modules/scanning-delegate-role/variables.tf
+++ b/modules/scanning-delegate-role/variables.tf
@@ -21,6 +21,12 @@ variable "scanner_roles" {
   type        = list(string)
 }
 
+variable "scanner_organization_unit_ids" {
+  description = "List of organization unit IDs allowed to assume this role"
+  type        = list(string)
+  default     = ["*"]
+}
+
 variable "tags" {
   description = "A map of additional tags to add to the IAM role/profile created"
   type        = map(string)

--- a/modules/scanning-delegate-role/variables.tf
+++ b/modules/scanning-delegate-role/variables.tf
@@ -21,8 +21,8 @@ variable "scanner_roles" {
   type        = list(string)
 }
 
-variable "scanner_organization_unit_ids" {
-  description = "List of organization unit IDs allowed to assume this role"
+variable "scanner_organizational_unit_ids" {
+  description = "List of AWS Organizations organizational units (OUs) allowed to assume this role"
   type        = list(string)
   default     = ["*"]
 }


### PR DESCRIPTION
In order to simplify the deployment of our role delegation system this PR introduces the following changes:

1. scanner role: rely on a wildcard for account ID to allow adding new delegate role without having to provide their full ARN explicitly and instead relying on a naming convention. The `account_roles` variable can still be provided to enforce a specific list of roles to assume, but it defaults to `arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole`
2. scanner role: allow specifying `organizational_unit_ids` to lock down the assumable roles to specific OUs.
3. delegate role: allow specifying `scanner_organizational_unit_ids` to lock down the originating OUs of scanner roles in the trust relationship.