### PR TITLE
Remove allowed_organizational_unit_ids

### DIFF
--- a/modules/agentless-scanner-role/README.md
+++ b/modules/agentless-scanner-role/README.md
@@ -40,7 +40,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless scanner can assume - make sure to respect the same naming convention as the agentless scanner role. | `list(string)` | <pre>[<br>  "arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole"<br>]</pre> | no |
-| <a name="input_allowed_organizational_unit_ids"></a> [allowed\_organizational\_unit\_ids](#input\_allowed\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) that are allowed to assume the Datadog agentless scanner role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_api_key_secret_arns"></a> [api\_key\_secret\_arns](#input\_api\_key\_secret\_arns) | List of ARNs of the secrets holding the Datadog API keys | `list(string)` | n/a | yes |
 | <a name="input_api_key_secret_kms_key_arns"></a> [api\_key\_secret\_kms\_key\_arns](#input\_api\_key\_secret\_kms\_key\_arns) | List of ARNs of the KMS keys encrypting the secrets | `list(string)` | `[]` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |

--- a/modules/agentless-scanner-role/main.tf
+++ b/modules/agentless-scanner-role/main.tf
@@ -51,12 +51,6 @@ data "aws_iam_policy_document" "scanner_policy_document" {
     effect    = "Allow"
     actions   = ["sts:AssumeRole"]
     resources = var.account_roles
-
-    condition {
-      test     = "ForAnyValue:StringLike"
-      variable = "aws:PrincipalOrgID"
-      values   = var.allowed_organizational_unit_ids
-    }
   }
 
   statement {

--- a/modules/agentless-scanner-role/variables.tf
+++ b/modules/agentless-scanner-role/variables.tf
@@ -4,12 +4,6 @@ variable "iam_role_name" {
   default     = "DatadogAgentlessScannerAgentRole"
 }
 
-variable "allowed_organizational_unit_ids" {
-  description = "List of AWS Organizations organizational units (OUs) that are allowed to assume the Datadog agentless scanner role"
-  type        = list(string)
-  default     = ["*"]
-}
-
 variable "iam_policy_name" {
   description = "Name to use on IAM policy created"
   type        = string


### PR DESCRIPTION
Rever part of #150. 

Field `allowed_organizational_unit_ids` was intended to rely on `aws:ResourceOrgID` instead of `aws:PrincipalOrgID`. But this global condition key `aws:ResourceOrgID` is not available for `AssumeRole`