### PR TITLE
Introducing `account_org_paths` to limit the reachable accounts by OU path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Version TBD
+## Version 0.11.5 - 2024-10-16
 
-- Scanner role delegations based on a account_id wildcard by default
+- Scanner role delegations based on a account_id wildcard by default: `account_roles` variable is now optional and defaults to allowing all accounts
+- Scanner role delegations can be limited to a specific list of organizational unit paths via the `account_org_paths` variable
 
 ## Version 0.11.4
 

--- a/modules/agentless-scanner-role/README.md
+++ b/modules/agentless-scanner-role/README.md
@@ -39,6 +39,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_account_org_paths"></a> [account\_org\_paths](#input\_account\_org\_paths) | List of AWS Organizations organizational unit (OU) paths in which the agentless scanner is allowed to assume role (default allows all) | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_account_roles"></a> [account\_roles](#input\_account\_roles) | List of cross accounts roles ARN that the Datadog agentless scanner can assume - make sure to respect the same naming convention as the agentless scanner role. | `list(string)` | <pre>[<br>  "arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole"<br>]</pre> | no |
 | <a name="input_api_key_secret_arns"></a> [api\_key\_secret\_arns](#input\_api\_key\_secret\_arns) | List of ARNs of the secrets holding the Datadog API keys | `list(string)` | n/a | yes |
 | <a name="input_api_key_secret_kms_key_arns"></a> [api\_key\_secret\_kms\_key\_arns](#input\_api\_key\_secret\_kms\_key\_arns) | List of ARNs of the KMS keys encrypting the secrets | `list(string)` | `[]` | no |

--- a/modules/agentless-scanner-role/main.tf
+++ b/modules/agentless-scanner-role/main.tf
@@ -53,6 +53,21 @@ data "aws_iam_policy_document" "scanner_policy_document" {
     resources = var.account_roles
   }
 
+  # Denying the ability to assume roles outside of the specified OU paths.
+  # Variable account_org_paths defaults to ["*"] which allows the role to be
+  # assumed from any OU
+  statement {
+    sid       = "EC2DenyAssumeRoleOutsideOUs"
+    actions   = ["sts:AssumeRole"]
+    effect    = "Deny"
+    resources = ["arn:aws:iam::*:*"]
+    condition {
+      test     = "ForAllValues:StringNotLike"
+      variable = "aws:ResourceOrgPaths"
+      values   = var.account_org_paths
+    }
+  }
+
   statement {
     sid       = "ReadSecret"
     actions   = ["secretsmanager:GetSecretValue"]

--- a/modules/agentless-scanner-role/variables.tf
+++ b/modules/agentless-scanner-role/variables.tf
@@ -28,6 +28,12 @@ variable "account_roles" {
   default     = ["arn:*:iam::*:role/DatadogAgentlessScannerDelegateRole"]
 }
 
+variable "account_org_paths" {
+  description = "List of AWS Organizations organizational unit (OU) paths in which the agentless scanner is allowed to assume role (default allows all)"
+  type        = list(string)
+  default     = ["*"]
+}
+
 variable "api_key_secret_arns" {
   description = "List of ARNs of the secrets holding the Datadog API keys"
   type        = list(string)


### PR DESCRIPTION
This PR introduces a new optional `account_org_paths` to the scanner role. This new variable can be used to enforce that the scanner can only reach for roles in the specified organisational unit paths.

Now that the `account_roles` is optional and defaults to a wildcard allowing to assume roles from any account, to limit the scope of the scanner role, without losing the convenience of specifying a account wildcard.