### PR TITLE
Prevent the agent from starting before it has been configured

### DIFF
--- a/azure/modules/custom-data/templates/install.sh.tftpl
+++ b/azure/modules/custom-data/templates/install.sh.tftpl
@@ -58,7 +58,11 @@ if [ -z "$agentless_version_custom" ]; then
   printf "Could not find a version of datadog-agentless-scanner from %s" "$DD_AGENTLESS_VERSION"
   exit 1
 fi
+# We mask/unmask because apt auto-starts the service, and we do
+# not want to start it before the configuration is in place.
+systemctl mask datadog-agentless-scanner.service
 apt install -y "datadog-agentless-scanner=$agentless_version_custom"
+systemctl unmask datadog-agentless-scanner.service
 
 # Adding automatic reboot on kernel updates
 cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades

--- a/azure/modules/custom-data/templates/install.sh.tftpl
+++ b/azure/modules/custom-data/templates/install.sh.tftpl
@@ -43,7 +43,8 @@ DD_AGENTLESS_CHANNEL="${scanner_channel}"
 hostnamectl hostname "$DD_HOSTNAME"
 
 # Install the agent
-DD_API_KEY="$DD_API_KEY" \
+DD_INSTALL_ONLY=true \
+  DD_API_KEY="$DD_API_KEY" \
   DD_SITE="$DD_SITE" \
   DD_HOSTNAME="$DD_HOSTNAME" \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -64,7 +64,11 @@ if [ -z "$agentless_version_custom" ]; then
   printf "Could not find a version of datadog-agentless-scanner from %s" "$DD_AGENTLESS_VERSION"
   exit 1
 fi
+# We mask/unmask because apt auto-starts the service, and we do
+# not want to start it before the configuration is in place.
+systemctl mask datadog-agentless-scanner.service
 apt install -y "datadog-agentless-scanner=$agentless_version_custom"
+systemctl unmask datadog-agentless-scanner.service
 
 # Adding automatic reboot on kernel updates
 cat << EOF >> /etc/apt/apt.conf.d/50unattended-upgrades
@@ -118,5 +122,4 @@ systemctl restart datadog-agent
 sleep 5
 
 # Enable and start datadog-agentless-scaner
-systemctl enable datadog-agentless-scanner
-systemctl start datadog-agentless-scanner
+systemctl enable --now datadog-agentless-scanner

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -49,7 +49,8 @@ DD_AGENTLESS_CHANNEL="${scanner_channel}"
 hostnamectl hostname "$DD_HOSTNAME"
 
 # Install the agent
-DD_API_KEY="$DD_API_KEY" \
+DD_INSTALL_ONLY=true \
+  DD_API_KEY="$DD_API_KEY" \
   DD_SITE="$DD_SITE" \
   DD_HOSTNAME="$DD_HOSTNAME" \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
@@ -111,7 +112,7 @@ EOF
 chmod 600 /etc/datadog-agent/agentless-scanner.yaml
 
 # Restart the agent
-service datadog-agent restart
+systemctl restart datadog-agent
 
 # Give some room to the agent to start to not miss logs
 sleep 5


### PR DESCRIPTION
Currently the agent is started automatically by the install script, before we set up its configuration files.
We later restart it to pick up the configuration changes, but it is faster and more reliable to only start it once the configuration is in place.