### PR TITLE
[SEC-17144] Move KMS Key to the S3 Module

### DIFF
--- a/examples/rds_scanning/main.tf
+++ b/examples/rds_scanning/main.tf
@@ -62,10 +62,8 @@ module "agentless_scanner_eu" {
 module "agentless_s3_bucket_us" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.11.7"
 
-  iam_delegate_role_arn   = module.delegate_role.role.arn
+  iam_delegate_role_name  = module.delegate_role.role.name
   iam_rds_assume_role_arn = module.agentless_scanner_us.role.arn
-  primary_kms_key_arn     = module.delegate_role.primary_kms_key.arn
-  primary_kms_key_region  = module.delegate_role.primary_kms_key_region
 
   providers = {
     aws = aws.us
@@ -75,10 +73,8 @@ module "agentless_s3_bucket_us" {
 module "agentless_s3_bucket_eu" {
   source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.11.7"
 
-  iam_delegate_role_arn   = module.delegate_role.role.arn
+  iam_delegate_role_name  = module.delegate_role.role.name
   iam_rds_assume_role_arn = module.agentless_scanner_eu.role.arn
-  primary_kms_key_arn     = module.delegate_role.primary_kms_key.arn
-  primary_kms_key_region  = module.delegate_role.primary_kms_key_region
 
   providers = {
     aws = aws.eu

--- a/modules/agentless-s3-bucket/README.md
+++ b/modules/agentless-s3-bucket/README.md
@@ -27,21 +27,22 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_kms_replica_key.replica](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_replica_key) | resource |
+| [aws_iam_policy.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.kms_key_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_kms_key.agentless_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_lifecycle_configuration.bucket_lifecycle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
 | [aws_s3_bucket_policy.bucket_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.bucket_access_block](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_iam_policy_document.bucket_access_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_iam_policy_document.kms_key_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_iam_delegate_role_arn"></a> [iam\_delegate\_role\_arn](#input\_iam\_delegate\_role\_arn) | The ARN of the Agentless Scanner Delegate role | `string` | n/a | yes |
-| <a name="input_primary_kms_key_arn"></a> [primary\_kms\_key\_arn](#input\_primary\_kms\_key\_arn) | Primary KMS key ARN to encrypt the exported data | `string` | n/a | yes |
-| <a name="input_primary_kms_key_region"></a> [primary\_kms\_key\_region](#input\_primary\_kms\_key\_region) | The region of the primary KMS key | `string` | n/a | yes |
+| <a name="input_iam_delegate_role_name"></a> [iam\_delegate\_role\_name](#input\_iam\_delegate\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerDelegateRole"` | no |
 | <a name="input_rds_service_role_arn"></a> [rds\_service\_role\_arn](#input\_rds\_service\_role\_arn) | The ARN of the service role used by RDS to write the export to the S3 bucket | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |
 

--- a/modules/agentless-s3-bucket/variables.tf
+++ b/modules/agentless-s3-bucket/variables.tf
@@ -10,17 +10,13 @@ variable "iam_delegate_role_arn" {
   type        = string
 }
 
+variable "iam_delegate_role_name" {
+  description = "Name to use on IAM role created"
+  type        = string
+  default     = "DatadogAgentlessScannerDelegateRole"
+}
+
 variable "rds_service_role_arn" {
   description = "The ARN of the service role used by RDS to write the export to the S3 bucket"
-  type        = string
-}
-
-variable "primary_kms_key_arn" {
-  description = "Primary KMS key ARN to encrypt the exported data"
-  type        = string
-}
-
-variable "primary_kms_key_region" {
-  description = "The region of the primary KMS key"
   type        = string
 }

--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -26,7 +26,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.kms_key_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.rds_service_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.scanning_orchestrator_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.scanning_rds_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -35,15 +34,11 @@ No modules.
 | [aws_iam_role.rds_service_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.delegate_role_rds_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.kms_key_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.orchestrator_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.rds_service_role_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.worker_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.workers_dspm_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_key.agentless_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.kms_key_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.rds_service_role_assume_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.rds_service_role_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.scanning_orchestrator_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -51,7 +46,6 @@ No modules.
 | [aws_iam_policy_document.scanning_worker_dspm_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.scanning_worker_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -69,8 +63,6 @@ No modules.
 
 | Name | Description |
 |------|-------------|
-| <a name="output_primary_kms_key"></a> [primary\_kms\_key](#output\_primary\_kms\_key) | The primary KMS key ARN to encrypt the exported data |
-| <a name="output_primary_kms_key_region"></a> [primary\_kms\_key\_region](#output\_primary\_kms\_key\_region) | The region of the primary KMS key |
 | <a name="output_rds_service_role_arn"></a> [rds\_service\_role\_arn](#output\_rds\_service\_role\_arn) | The ARN of the service role used by RDS to write the export to the S3 bucket |
 | <a name="output_role"></a> [role](#output\_role) | The scanning role created |
 <!-- END_TF_DOCS -->

--- a/modules/scanning-delegate-role/outputs.tf
+++ b/modules/scanning-delegate-role/outputs.tf
@@ -5,15 +5,5 @@ output "role" {
 
 output "rds_service_role_arn" {
   description = "The ARN of the service role used by RDS to write the export to the S3 bucket"
-  value       = aws_iam_role.role.arn
-}
-
-output "primary_kms_key" {
-  description = "The primary KMS key ARN to encrypt the exported data"
-  value       = aws_kms_key.agentless_kms_key[0].arn
-}
-
-output "primary_kms_key_region" {
-  description = "The region of the primary KMS key"
-  value       = data.aws_region.current.name
+  value       = length(aws_iam_role.rds_service_role) > 0 ? one(aws_iam_role.rds_service_role).arn : null
 }


### PR DESCRIPTION
Move the KMS Key that used to be created in the delegate role out of the IAM module into the S3 Bucket Module.
There will be a KMS Key for each region we deploy the bucket to.