### PR TITLE
Relax the scanner_version condition

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -16,8 +16,8 @@ variable "scanner_version" {
   type        = string
   default     = "0.11"
   validation {
-    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.scanner_version))
-    error_message = "The scanner version must be in the format of X.Y"
+    condition     = can(regex("^[0-9]+\\.[0-9]+", var.scanner_version))
+    error_message = "The scanner version must start with a number, followed by a period and a number (X.Y)"
   }
 }
 


### PR DESCRIPTION
In order to allow more complex filtering based on the scanner version, let's allow to give more precision to the scanner_version and only enforce that it starts with `X.Y`.