### PR TITLE
Relax the scanner_version condition in user_data module

### DIFF
--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -10,8 +10,8 @@ variable "scanner_version" {
   type        = string
   default     = "0.11"
   validation {
-    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.scanner_version))
-    error_message = "The scanner version must be in the format of X.Y"
+    condition     = can(regex("^[0-9]+\\.[0-9]+", var.scanner_version))
+    error_message = "The scanner version must start with a number, followed by a period and a number (X.Y)"
   }
 }
 


### PR DESCRIPTION
Followup on #161. Missing the relaxation of the validation in the user_data module.