### PR TITLE
Add scanner_repository to specify host of the APT repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ No resources.
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance running the scanner | `string` | `"t4g.large"` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta). | `string` | `"stable"` | no |
 | <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly. | `any` | `{}` | no |
+| <a name="input_scanner_repository"></a> [scanner\_repository](#input\_scanner\_repository) | Repository URL to install the scanner from. | `string` | `"https://apt.datadoghq.com/"` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ module "user_data" {
   api_key               = var.api_key
   api_key_secret_arn    = var.api_key_secret_arn
   scanner_channel       = var.scanner_channel
+  scanner_repository    = var.scanner_repository
   scanner_version       = var.scanner_version
   scanner_configuration = var.scanner_configuration
   agent_configuration   = var.agent_configuration

--- a/modules/user_data/README.md
+++ b/modules/user_data/README.md
@@ -41,6 +41,7 @@ No modules.
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable | `string` | `null` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Specifies the channel to use for installing the scanner | `string` | `"stable"` | no |
 | <a name="input_scanner_configuration"></a> [scanner\_configuration](#input\_scanner\_configuration) | Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly. | `any` | `{}` | no |
+| <a name="input_scanner_repository"></a> [scanner\_repository](#input\_scanner\_repository) | Repository URL to install the scanner from. | `string` | `"https://apt.datadoghq.com/"` | no |
 | <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version) | Specifies the version of the scanner to install | `string` | `"0.11"` | no |
 | <a name="input_site"></a> [site](#input\_site) | By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/ | `string` | `"datadoghq.com"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to the resources | `map(string)` | `{}` | no |

--- a/modules/user_data/main.tf
+++ b/modules/user_data/main.tf
@@ -47,6 +47,7 @@ resource "terraform_data" "template" {
     site                  = var.site,
     scanner_version       = var.scanner_version,
     scanner_channel       = var.scanner_channel,
+    scanner_repository    = var.scanner_repository,
     scanner_configuration = var.scanner_configuration,
     agent_configuration   = local.custom_agent_configuration,
     region                = data.aws_region.current.name,

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -31,6 +31,7 @@ DD_HOSTNAME="agentless-scanning-$IMDS_AWS_REGION-$IMDS_INSTANCE_ID"
 DD_SITE="${site}"
 DD_API_KEY="ENC[${api_key_secret_arn}]"
 DD_AGENTLESS_VERSION="${scanner_version}"
+DD_AGENTLESS_REPOSITORY="${scanner_repository}"
 DD_AGENTLESS_CHANNEL="${scanner_channel}"
 
 hostnamectl hostname "$DD_HOSTNAME"
@@ -43,7 +44,7 @@ DD_INSTALL_ONLY=true \
   bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
 
 # Install the agentless-scanner
-echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] https://apt.datadoghq.com/ $DD_AGENTLESS_CHANNEL agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
+echo "deb [signed-by=/usr/share/keyrings/datadog-archive-keyring.gpg] $DD_AGENTLESS_REPOSITORY $DD_AGENTLESS_CHANNEL agentless-scanner" >> /etc/apt/sources.list.d/datadog.list
 apt update
 agentless_pkg_pattern="([[:digit:]]:)?$DD_AGENTLESS_VERSION(\.[[:digit:]]+){0,1}(~rc\.[[:digit:]]+)?(-[[:digit:]])?"
 agentless_version_custom="$(apt-cache madison datadog-agentless-scanner | grep -E "$agentless_pkg_pattern" -om1)" || true

--- a/modules/user_data/variables.tf
+++ b/modules/user_data/variables.tf
@@ -25,6 +25,16 @@ variable "scanner_channel" {
   }
 }
 
+variable "scanner_repository" {
+  description = "Repository URL to install the scanner from."
+  type        = string
+  default     = "https://apt.datadoghq.com/"
+  validation {
+    condition     = can(regex("^https://", var.scanner_repository))
+    error_message = "The scanner repository must be a valid HTTPs URL"
+  }
+}
+
 variable "scanner_configuration" {
   description = "Specifies a custom configuration for the scanner. The specified object is passed directly as a configuration input for the scanner. Warning: this is an advanced feature and can break the scanner if not used correctly."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,16 @@ variable "scanner_channel" {
   }
 }
 
+variable "scanner_repository" {
+  description = "Repository URL to install the scanner from."
+  type        = string
+  default     = "https://apt.datadoghq.com/"
+  validation {
+    condition     = can(regex("^https://", var.scanner_repository))
+    error_message = "The scanner repository must be a valid HTTPs URL"
+  }
+}
+
 variable "site" {
   description = "By default the Agent sends its data to Datadog US site. If your organization is on another site, you must update it. See https://docs.datadoghq.com/getting_started/site/"
   type        = string


### PR DESCRIPTION
Adds a new `scanner_repository` variable to main and user_data modules. This parameter is used as the URL of the APT repository from which we fetch our scanner releases. Defaults to  `https://apt.datadoghq.com/`.