### PR TITLE
azure: relax condition on scan_version variable

### DIFF
--- a/azure/modules/custom-data/variables.tf
+++ b/azure/modules/custom-data/variables.tf
@@ -22,8 +22,8 @@ variable "scanner_version" {
   type        = string
   default     = "0.11"
   validation {
-    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.scanner_version))
-    error_message = "The scanner version must be in the format of X.Y"
+    condition     = can(regex("^[0-9]+\\.[0-9]+", var.scanner_version))
+    error_message = "The scanner version must start with a number, followed by a period and a number (X.Y)"
   }
 }
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -72,8 +72,8 @@ variable "scanner_version" {
   type        = string
   default     = "0.11"
   validation {
-    condition     = can(regex("^[0-9]+\\.[0-9]+$", var.scanner_version))
-    error_message = "The scanner version must be in the format of X.Y"
+    condition     = can(regex("^[0-9]+\\.[0-9]+", var.scanner_version))
+    error_message = "The scanner version must start with a number, followed by a period and a number (X.Y)"
   }
 }
 


### PR DESCRIPTION
Let's sync with how our AWS module works. This allows passing more complex conditions on the versions installed.