### PR TITLE
[SEC-17145] Remove ListBucket from Denied actions in S3 bucket

### DIFF
--- a/modules/agentless-s3-bucket/main.tf
+++ b/modules/agentless-s3-bucket/main.tf
@@ -97,11 +97,9 @@ data "aws_iam_policy_document" "bucket_access_policy_document" {
     effect = "Deny"
     actions = [
       "s3:GetObject*",
-      "s3:ListBucket",
       "s3:PutObject*",
     ]
     resources = [
-      aws_s3_bucket.bucket.arn,
       "${aws_s3_bucket.bucket.arn}/*",
     ]
     principals {


### PR DESCRIPTION
To deploy to production, we need to allow the HeadBucket action to the role used by TF:
https://gitlab.ddbuild.io/DataDog/cloud-inventory/-/jobs/732992334

> Error: reading S3 Bucket (datadog-agentless-scanning-20241210143920542100000001): operation error S3: HeadBucket, https response error StatusCode: 403, RequestID: DQF66JMRJYHQ42KE, HostID: 6GU95QuHjrKmnF4+5MWe50iR5lGa8WQQ4ADeHn2mvIHrio5ewRL3jSDAfYbhd9hyVS1J+Dv2RvhrU14GahyBMsmn6mIqwq2d73mjJ9MT1Ak=, api error Forbidden: Forbidden


