### PR TITLE
Use Ubuntu 24.04 Minimal Server image on AWS

### DIFF
--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -36,7 +36,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | Size of the autoscaling group the instance is in (i.e. number of instances to run) | `number` | `1` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile | `string` | n/a | yes |
-| <a name="input_instance_image_id"></a> [instance\_image\_id](#input\_instance\_image\_id) | The Image ID (aka. AMI) used as baseline for the instance - SSM parameter path is allowed | `string` | `"resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"` | no |
+| <a name="input_instance_image_id"></a> [instance\_image\_id](#input\_instance\_image\_id) | The Image ID (aka. AMI) used as baseline for the instance - SSM parameter path is allowed | `string` | `"resolve:ssm:/aws/service/canonical/ubuntu/server-minimal/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"` | no |
 | <a name="input_instance_root_volume_size"></a> [instance\_root\_volume\_size](#input\_instance\_root\_volume\_size) | The instance root volume size in GiB | `number` | `30` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance | `string` | `"t4g.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -13,7 +13,7 @@ variable "instance_type" {
 variable "instance_image_id" {
   description = "The Image ID (aka. AMI) used as baseline for the instance - SSM parameter path is allowed"
   type        = string
-  default     = "resolve:ssm:/aws/service/canonical/ubuntu/server/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"
+  default     = "resolve:ssm:/aws/service/canonical/ubuntu/server-minimal/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"
 }
 
 variable "instance_root_volume_size" {

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -18,7 +18,11 @@ echo "options nbd nbds_max=128" > /etc/modprobe.d/nbd.conf
 
 # Install requirements
 apt update
-apt install -y nbd-client curl
+apt install -y curl
+
+# Remove uneeded packages
+apt remove -y libx11-6
+apt autoremove -y
 
 # Get IMDS metadata to fetch the API Key from SecretsManager (without having to install awscli)
 IMDS_TOKEN=$(      curl -sSL -XPUT "http://169.254.169.254/latest/api/token"                  -H "X-AWS-EC2-Metadata-Token-TTL-Seconds: 30")


### PR DESCRIPTION
This change uses Ubuntu 24.04 Minimal Server image instead of Ubuntu 24.04 Server image on AWS.

This provides a smaller Ubuntu installation, which should decrease the amount of known vulnerabilities.