### PR TITLE
Fix Bicep pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,8 +57,14 @@ repos:
 
   - repo: local
     hooks:
+    - id: bicep-install
+      name: Install Azure Bicep CLI
+      description: This hook installs the same version of the Azure Bicep CLI that was used to build the ARM template.
+      language: system
+      entry: sh -c 'az bicep install --version $(jq -r '\''.metadata._generator.version | split(".")[:3] | ("v" + join("."))'\'' "${0%.bicep}.json")'
+      files: ^azure/arm/main.bicep$
     - id: bicep-build
-      name: Build Azure ARM template
+      name: Build Azure ARM template with Bicep
       language: system
       entry: az bicep build --file
       files: ^azure/arm/main.bicep$


### PR DESCRIPTION
The Bicep CLI version in CI is updated periodically. We need to ensure that we run the pre-commit hook with the same version that was originally used to build the template, otherwise there will always be changes and the pre-commit hook will fail.

We can get the exact version used from `.metadata._generator.version` in the template itself. However, `az bicep install` expects the version to be passed in a different format: only the first three components and with a `v` prefix. We use `jq` to convert it to the expected format.