### PR TITLE
[AUTOSCALING] Add Agentless Scanners autoscaling module

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ No resources.
 | <a name="input_api_key_secret_arn"></a> [api\_key\_secret\_arn](#input\_api\_key\_secret\_arn) | ARN of the secret holding the Datadog API key. Takes precedence over api\_key variable - Make sure the API key is Remote Configuration enabled. | `string` | `null` | no |
 | <a name="input_enable_ssm"></a> [enable\_ssm](#input\_enable\_ssm) | Whether to enable AWS SSM to facilitate executing troubleshooting commands on the instance | `bool` | `false` | no |
 | <a name="input_enable_ssm_vpc_endpoint"></a> [enable\_ssm\_vpc\_endpoint](#input\_enable\_ssm\_vpc\_endpoint) | Whether to enable AWS SSM VPC endpoint (only applicable if enable\_ssm is true) | `bool` | `true` | no |
-| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Size of the autoscaling group the instance is in (i.e. number of instances with scanners to run) | `number` | `1` | no |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Default size of the autoscaling group the instance is in (i.e. number of instances with scanners to run) | `number` | `1` | no |
 | <a name="input_instance_profile_name"></a> [instance\_profile\_name](#input\_instance\_profile\_name) | Name of the instance profile to attach to the instance | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance running the scanner | `string` | `"t4g.large"` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Channel of the scanner to install from (stable or beta). | `string` | `"stable"` | no |

--- a/modules/agentless-scanners-autoscaling/README.md
+++ b/modules/agentless-scanners-autoscaling/README.md
@@ -1,0 +1,33 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role_policy.agentless_autoscaling_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_policy_document.agentless_autoscaling_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_datadog_integration_role"></a> [datadog\_integration\_role](#input\_datadog\_integration\_role) | Role name of the Datadog Integration that was used to integrate the AWS account to Datadog | `string` | `null` | no |
+
+## Outputs
+
+No outputs.

--- a/modules/agentless-scanners-autoscaling/README.md
+++ b/modules/agentless-scanners-autoscaling/README.md
@@ -26,7 +26,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_datadog_integration_role"></a> [datadog\_integration\_role](#input\_datadog\_integration\_role) | Role name of the Datadog Integration that was used to integrate the AWS account to Datadog | `string` | `null` | no |
+| <a name="input_datadog_integration_role"></a> [datadog\_integration\_role](#input\_datadog\_integration\_role) | Role name of the Datadog integration that was used to integrate the AWS account to Datadog | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/agentless-scanners-autoscaling/README.md
+++ b/modules/agentless-scanners-autoscaling/README.md
@@ -21,12 +21,13 @@ No modules.
 |------|------|
 | [aws_iam_role_policy.agentless_autoscaling_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_policy_document.agentless_autoscaling_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_datadog_integration_role"></a> [datadog\_integration\_role](#input\_datadog\_integration\_role) | Role name of the Datadog integration that was used to integrate the AWS account to Datadog | `string` | `null` | no |
+| <a name="input_datadog_integration_role"></a> [datadog\_integration\_role](#input\_datadog\_integration\_role) | Role name of the Datadog integration that was used to integrate the scanners' AWS account to Datadog | `string` | `null` | no |
 
 ## Outputs
 

--- a/modules/agentless-scanners-autoscaling/main.tf
+++ b/modules/agentless-scanners-autoscaling/main.tf
@@ -1,0 +1,26 @@
+resource "aws_iam_role_policy" "agentless_autoscaling_policy" {
+  name   = "DatadogAgentlessScannerAutoscalingPolicy"
+  role   = var.datadog_integration_role
+  policy = data.aws_iam_policy_document.agentless_autoscaling_policy_document.json
+
+}
+
+data "aws_iam_policy_document" "agentless_autoscaling_policy_document" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "autoscaling:StartInstanceRefresh",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:DescribeAutoScalingGroups",
+      "ec2:GetConsoleOutput",
+    ]
+    resources = ["*"]
+    // Enforce that any of these actions can be performed on resources
+    // that have the DatadogAgentlessScanner tag.
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/DatadogAgentlessScanner"
+      values   = ["true"]
+    }
+  }
+}

--- a/modules/agentless-scanners-autoscaling/main.tf
+++ b/modules/agentless-scanners-autoscaling/main.tf
@@ -1,3 +1,5 @@
+data "aws_partition" "current" {}
+
 resource "aws_iam_role_policy" "agentless_autoscaling_policy" {
   name   = "DatadogAgentlessScannerAutoscalingPolicy"
   role   = var.datadog_integration_role
@@ -14,7 +16,10 @@ data "aws_iam_policy_document" "agentless_autoscaling_policy_document" {
       "autoscaling:DescribeAutoScalingGroups",
       "ec2:GetConsoleOutput",
     ]
-    resources = ["*"]
+    resources = [
+      "arn:${data.aws_partition.current.partition}:autoscaling:*:*:autoScalingGroup:*",
+      "arn:${data.aws_partition.current.partition}:ec2:*:*:instance/*",
+    ]
     // Enforce that any of these actions can be performed on resources
     // that have the DatadogAgentlessScanner tag.
     condition {

--- a/modules/agentless-scanners-autoscaling/main.tf
+++ b/modules/agentless-scanners-autoscaling/main.tf
@@ -13,7 +13,6 @@ data "aws_iam_policy_document" "agentless_autoscaling_policy_document" {
     actions = [
       "autoscaling:StartInstanceRefresh",
       "autoscaling:SetDesiredCapacity",
-      "autoscaling:DescribeAutoScalingGroups",
       "ec2:GetConsoleOutput",
     ]
     resources = [
@@ -27,5 +26,13 @@ data "aws_iam_policy_document" "agentless_autoscaling_policy_document" {
       variable = "aws:ResourceTag/DatadogAgentlessScanner"
       values   = ["true"]
     }
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
+      "autoscaling:DescribeAutoScalingGroups",
+    ]
+    resources = ["*"]
   }
 }

--- a/modules/agentless-scanners-autoscaling/outputs.tf
+++ b/modules/agentless-scanners-autoscaling/outputs.tf
@@ -1,0 +1,1 @@
+# No outputs for now

--- a/modules/agentless-scanners-autoscaling/provider.tf
+++ b/modules/agentless-scanners-autoscaling/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}

--- a/modules/agentless-scanners-autoscaling/variables.tf
+++ b/modules/agentless-scanners-autoscaling/variables.tf
@@ -1,5 +1,5 @@
 variable "datadog_integration_role" {
-  description = "Role name of the Datadog Integration that was used to integrate the scanners' AWS account to Datadog"
+  description = "Role name of the Datadog integration that was used to integrate the scanners' AWS account to Datadog"
   type        = string
   default     = null
 }

--- a/modules/agentless-scanners-autoscaling/variables.tf
+++ b/modules/agentless-scanners-autoscaling/variables.tf
@@ -1,0 +1,6 @@
+variable "datadog_integration_role" {
+  description = "Role name of the Datadog Integration that was used to integrate the scanners' AWS account to Datadog"
+  type        = string
+  default     = null
+}
+

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -34,12 +34,14 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | Size of the autoscaling group the instance is in (i.e. number of instances to run) | `number` | `1` | no |
+| <a name="input_asg_size"></a> [asg\_size](#input\_asg\_size) | Default size of the autoscaling group the instance is in (i.e. default number of instances to run) | `number` | `1` | no |
 | <a name="input_iam_instance_profile"></a> [iam\_instance\_profile](#input\_iam\_instance\_profile) | IAM Instance Profile to launch the instance with. Specified as the name of the Instance Profile | `string` | n/a | yes |
 | <a name="input_instance_image_id"></a> [instance\_image\_id](#input\_instance\_image\_id) | The Image ID (aka. AMI) used as baseline for the instance - SSM parameter path is allowed | `string` | `"resolve:ssm:/aws/service/canonical/ubuntu/server-minimal/24.04/stable/current/arm64/hvm/ebs-gp3/ami-id"` | no |
 | <a name="input_instance_root_volume_size"></a> [instance\_root\_volume\_size](#input\_instance\_root\_volume\_size) | The instance root volume size in GiB | `number` | `30` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance | `string` | `"t4g.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
+| <a name="input_max_asg_size"></a> [max\_asg\_size](#input\_max\_asg\_size) | Maximum size of the autoscaling group the instance is in (i.e. maximum number of instances to run) | `number` | `10` | no |
+| <a name="input_min_asg_size"></a> [min\_asg\_size](#input\_min\_asg\_size) | Minimum size of the autoscaling group the instance is in (i.e. minimum number of instances to run) | `number` | `0` | no |
 | <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix to be used on EC2 instance created | `string` | `"DatadogAgentlessScanner"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | The VPC Subnet IDs to launch in | `list(string)` | n/a | yes |

--- a/modules/instance/README.md
+++ b/modules/instance/README.md
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_instance_root_volume_size"></a> [instance\_root\_volume\_size](#input\_instance\_root\_volume\_size) | The instance root volume size in GiB | `number` | `30` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The type of instance | `string` | `"t4g.large"` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | Key name of the Key Pair to use for the instance; which can be managed using the `aws_key_pair` resource | `string` | `null` | no |
-| <a name="input_max_asg_size"></a> [max\_asg\_size](#input\_max\_asg\_size) | Maximum size of the autoscaling group the instance is in (i.e. maximum number of instances to run) | `number` | `10` | no |
+| <a name="input_max_asg_size"></a> [max\_asg\_size](#input\_max\_asg\_size) | Maximum size of the autoscaling group the instance is in (i.e. maximum number of instances to run) | `number` | `50` | no |
 | <a name="input_min_asg_size"></a> [min\_asg\_size](#input\_min\_asg\_size) | Minimum size of the autoscaling group the instance is in (i.e. minimum number of instances to run) | `number` | `0` | no |
 | <a name="input_monitoring"></a> [monitoring](#input\_monitoring) | If true, the launched EC2 instance will have detailed monitoring enabled | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix to be used on EC2 instance created | `string` | `"DatadogAgentlessScanner"` | no |

--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -74,8 +74,8 @@ resource "aws_security_group" "default_scanner_security_group" {
 
 resource "aws_autoscaling_group" "asg" {
   name_prefix      = "datadog-agentless-scanner-asg"
-  min_size         = var.asg_size
-  max_size         = var.asg_size
+  min_size         = var.min_asg_size
+  max_size         = var.max_asg_size
   desired_capacity = var.asg_size
 
   # references:

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -61,11 +61,25 @@ variable "monitoring" {
   default     = false
 }
 
+variable "min_asg_size" {
+  description = "Minimum size of the autoscaling group the instance is in (i.e. minimum number of instances to run)"
+  type        = number
+  default     = 0
+}
+
+variable "max_asg_size" {
+  description = "Maximum size of the autoscaling group the instance is in (i.e. maximum number of instances to run)"
+  type        = number
+  default     = 10
+}
+
 variable "asg_size" {
-  description = "Size of the autoscaling group the instance is in (i.e. number of instances to run)"
+  description = "Default size of the autoscaling group the instance is in (i.e. default number of instances to run)"
   type        = number
   default     = 1
 }
+
+
 
 variable "tags" {
   description = "A map of additional tags to add to the instance/volume created"

--- a/modules/instance/variables.tf
+++ b/modules/instance/variables.tf
@@ -70,7 +70,7 @@ variable "min_asg_size" {
 variable "max_asg_size" {
   description = "Maximum size of the autoscaling group the instance is in (i.e. maximum number of instances to run)"
   type        = number
-  default     = 10
+  default     = 50
 }
 
 variable "asg_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "instance_type" {
 }
 
 variable "instance_count" {
-  description = "Size of the autoscaling group the instance is in (i.e. number of instances with scanners to run)"
+  description = "Default size of the autoscaling group the instance is in (i.e. number of instances with scanners to run)"
   type        = number
   default     = 1
 }


### PR DESCRIPTION
Add Agentless Scanners autoscaling module. 

This module attaches the AutoScaling policy to the Datadog Integration Role that was used to onboard the scanners' AWS account to Datadog. 