### PR TITLE
[SEC-21739] add(agentless-azure): add ap2 to agentless azure TF templates

### DIFF
--- a/azure/arm/main.bicep
+++ b/azure/arm/main.bicep
@@ -19,6 +19,7 @@ param datadogAppKey string = ''
   'us3.datadoghq.com'
   'us5.datadoghq.com'
   'ap1.datadoghq.com'
+  'ap2.datadoghq.com'
   'datad0g.com'
 ])
 param datadogSite string = 'datadoghq.com'

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -59,6 +59,7 @@
         "us3.datadoghq.com",
         "us5.datadoghq.com",
         "ap1.datadoghq.com",
+        "ap2.datadoghq.com",
         "datad0g.com"
       ],
       "metadata": {

--- a/azure/arm/uiFormDefinition.json
+++ b/azure/arm/uiFormDefinition.json
@@ -105,6 +105,10 @@
                                     {
                                         "label": "ap1.datadoghq.com",
                                         "value": "ap1.datadoghq.com"
+                                    },
+                                    {
+                                        "label": "ap2.datadoghq.com",
+                                        "value": "ap2.datadoghq.com"
                                     }
                                 ]
                             },


### PR DESCRIPTION
What?
=====
- Add ap2 to allowed DC values in Azure TF templates.

Why?
=====
- Required for the migration to AP2.