### PR TITLE
release: update CHANGELOG for prep of 0.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Version 0.11.11 - 2025-06-16
+
+- Adapt CopySnapshot policy to latest IAM changes requiring both source and destination statements
+- Use t4g.medium instance type for Agentless ec2 instances
+- Remove unnecessary ec2:CopyImage permission
+
+## Version 0.11.10 - 2025-04-24
+
+- aws: add autoscaling module allowing the automated auto-scaling of scanners
+- azure/arm: upgrade az bicep version
+- azure/arm: call Agentless API on deployment
+
 ## Version 0.11.9 - 2025-02-14
 
 - Azure: expose vnet_cidr parameter in main module

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -5,8 +5,8 @@
   "metadata": {
     "_generator": {
       "name": "bicep",
-      "version": "0.35.1.17967",
-      "templateHash": "5865216794841539464"
+      "version": "0.36.1.42791",
+      "templateHash": "3525611388986193764"
     }
   },
   "functions": [
@@ -595,8 +595,8 @@
           "metadata": {
             "_generator": {
               "name": "bicep",
-              "version": "0.35.1.17967",
-              "templateHash": "16228574457820060691"
+              "version": "0.36.1.42791",
+              "templateHash": "5157009170949077817"
             }
           },
           "parameters": {

--- a/azure/modules/custom-data/templates/install.sh.tftpl
+++ b/azure/modules/custom-data/templates/install.sh.tftpl
@@ -131,7 +131,7 @@ api_key: $DD_API_KEY
 site: $DD_SITE
 azure_client_id: ${azure_client_id}
 installation_mode: terraform
-installation_version: 0.11.7
+installation_version: 0.11.11
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -127,7 +127,7 @@ hostname: $DD_HOSTNAME
 api_key: $DD_API_KEY
 site: $DD_SITE
 installation_mode: terraform
-installation_version: 0.11.7
+installation_version: 0.11.11
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}


### PR DESCRIPTION
Update the CHANGELOG for preparing the v0.11.11 release.

Also backfill the CHANGELOG for v0.11.10.