### PR TITLE
Fix Bicep pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
       name: Install Azure Bicep CLI
       description: This hook installs the same version of the Azure Bicep CLI that was used to build the ARM template.
       language: system
-      entry: sh -c 'az bicep install --version $(jq -r '\''.metadata._generator.version | split(".")[:3] | ("v" + join("."))'\'' "${0%.bicep}.json")'
+      entry: sh -c 'az config set bicep.use_binary_from_path=False; az bicep install --version $(jq -r '\''.metadata._generator.version | split(".")[:3] | ("v" + join("."))'\'' "${0%.bicep}.json")'
       files: ^azure/arm/main.bicep$
     - id: bicep-build
       name: Build Azure ARM template with Bicep


### PR DESCRIPTION
`az bicep install` doesn't work properly in CI because it always uses the version in `PATH`.
Setting `bicep.use_binary_from_path=False` disabled this behavior and allows us to control the bicep version.