### PR TITLE
Rework Bicep pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,14 +57,19 @@ repos:
 
   - repo: local
     hooks:
-    - id: bicep-install
-      name: Install Azure Bicep CLI
-      description: This hook installs the same version of the Azure Bicep CLI that was used to build the ARM template.
-      language: system
-      entry: sh -c 'az config set bicep.use_binary_from_path=False; az bicep install --version $(jq -r '\''.metadata._generator.version | split(".")[:3] | ("v" + join("."))'\'' "${0%.bicep}.json")'
-      files: ^azure/arm/main.bicep$
-    - id: bicep-build
-      name: Build Azure ARM template with Bicep
-      language: system
-      entry: az bicep build --file
-      files: ^azure/arm/main.bicep$
+      - id: bicep
+        name: Build Azure ARM template with Bicep
+        language: system
+        # Note: to avoid errors every time a new Bicep version is released,
+        # we need to install and use the same version of Bicep CLI that was
+        # used to build the ARM template.
+        entry: >-
+          sh -c '
+            az config set bicep.use_binary_from_path=False;
+            BICEP_VERSION=v$(jq -r '\''.metadata._generator.version | split(".")[:3] | join(".")'\'' azure/arm/main.json);
+            az bicep install --version $BICEP_VERSION;
+            az bicep build --file azure/arm/main.bicep;
+          '
+        files: ^azure/arm/
+        exclude_types: ["markdown"]
+        pass_filenames: false


### PR DESCRIPTION
We need to run this hook not just when the main template changes, but also whenever any of the template inputs change, including the scripts.

To simplify (and future-proof) things, let's run the hook whenever any of the files in this directory change (except the README).

I also combined the azure-install and azure-build hooks because they always need to run together anyway.