### PR TITLE
chore: update module references from v0.11.10 to v0.11.11

### DIFF
--- a/examples/cross_account/other_account/main.tf
+++ b/examples/cross_account/other_account/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles = [var.scanner_role_arn]
 }

--- a/examples/cross_account/scanner_account/main.tf
+++ b/examples/cross_account/scanner_account/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.11"
 
   ## By default the scanner can assume any role with the default naming
   ## convention from any account.
@@ -40,19 +40,19 @@ module "scanner_role" {
 }
 
 module "self_delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   api_key               = var.api_key
   instance_profile_name = module.scanner_role.instance_profile.name
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.10"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.11"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/custom_agent_configurations/main.tf
+++ b/examples/custom_agent_configurations/main.tf
@@ -14,19 +14,19 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.11"
 
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   api_key               = var.api_key
   instance_profile_name = module.scanner_role.instance_profile.name
@@ -73,6 +73,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.10"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.11"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/custom_vpc/main.tf
+++ b/examples/custom_vpc/main.tf
@@ -14,24 +14,24 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.11"
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles = [module.agentless_scanner_role.role.arn]
 }
 
 module "user_data" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/user_data?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/user_data?ref=0.11.11"
 
   hostname = "agentless-scanning-us-east-1"
   api_key  = var.api_key
 }
 
 module "instance" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/instance?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/instance?ref=0.11.11"
 
   user_data            = module.user_data.install_sh
   iam_instance_profile = module.agentless_scanner_role.profile.name
@@ -40,6 +40,6 @@ module "instance" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.10"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.11"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.11"
 
   api_key_secret_arns = [
     module.agentless_scanner_us.api_key_secret_arn,
@@ -29,13 +29,13 @@ module "agentless_scanner_role" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles = [module.agentless_scanner_role.role.arn]
 }
 
 module "agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   providers = {
     aws = aws.us
@@ -46,7 +46,7 @@ module "agentless_scanner_us" {
 }
 
 module "agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   providers = {
     aws = aws.eu
@@ -57,6 +57,6 @@ module "agentless_scanner_eu" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.10"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.11"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/rds_scanning/main.tf
+++ b/examples/rds_scanning/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.11"
 
   account_roles = [module.delegate_role.role.arn]
   api_key_secret_arns = [
@@ -30,14 +30,14 @@ module "agentless_scanner_role" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles                       = [module.agentless_scanner_role.role.arn]
   sensitive_data_scanning_rds_enabled = true
 }
 
 module "agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   providers = {
     aws = aws.us
@@ -48,7 +48,7 @@ module "agentless_scanner_us" {
 }
 
 module "agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   providers = {
     aws = aws.eu
@@ -60,7 +60,7 @@ module "agentless_scanner_eu" {
 
 
 module "agentless_s3_bucket_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.11.11"
 
   iam_delegate_role_name  = module.delegate_role.role.name
   iam_rds_assume_role_arn = module.agentless_scanner_us.role.arn
@@ -71,7 +71,7 @@ module "agentless_s3_bucket_us" {
 }
 
 module "agentless_s3_bucket_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.11.11"
 
   iam_delegate_role_name  = module.delegate_role.role.name
   iam_rds_assume_role_arn = module.agentless_scanner_eu.role.arn
@@ -82,6 +82,6 @@ module "agentless_s3_bucket_eu" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.10"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.11"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/single_region/main.tf
+++ b/examples/single_region/main.tf
@@ -14,25 +14,25 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.11.11"
 
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.11.11"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.10"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.11.11"
 
   api_key               = var.api_key
   instance_profile_name = module.scanner_role.instance_profile.name
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.10"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.11.11"
   datadog_integration_role = var.datadog_integration_role
 }


### PR DESCRIPTION
This pull request updates all example Terraform configurations to use version `0.11.11` of the `terraform-module-datadog-agentless-scanner` module, replacing the previous `0.11.10` references.