### PR TITLE
Remove Docs Team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,6 +13,6 @@
 
 ## Docs
 
-/docs/     @DataDog/documentation @DataDog/k9-agentless
-/examples/ @DataDog/documentation @DataDog/k9-agentless
-*README.md @DataDog/documentation @DataDog/k9-agentless
+/docs/     @DataDog/k9-agentless
+/examples/ @DataDog/k9-agentless
+*README.md @DataDog/k9-agentless


### PR DESCRIPTION
Removes Docs as CODEOWNERS from the repo. As part of a project to reduce courtesy reviews, the Docs Team is limiting CODEOWNERS entries to repos that single-source content into the docs site or where our review is critical. We’re still happy to review content if you reach out to us directly.