### PR TITLE
[K9VULN-7306] [Agentless] Add documentation and TF docs for GCP modules

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -1,0 +1,114 @@
+# Terraform Module Datadog Agentless Scanner Module
+
+This Terraform module provides a simple and reusable configuration for installing a Datadog Agentless Scanner on Google Cloud Platform (GCP).
+
+## Prerequisites
+
+Before using this module, make sure you have the following:
+
+1. [Terraform](https://www.terraform.io/) installed on your local machine.
+2. The [Google Cloud CLI](https://cloud.google.com/sdk/docs/install) installed on your local machine.
+3. GCP credentials configured (`gcloud auth login`) with the necessary permissions.
+
+## Usage
+
+To use this module in your Terraform configuration, add the following code in your existing Terraform code:
+
+```hcl
+variable "datadog-api-key" {}
+
+module "datadog-agentless-scanner" {
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp"
+
+  site           = "datadoghq.com"
+  vpc_name       = "datadog-agentless-scanner"
+  api_key        = var.datadog-api-key
+}
+```
+
+And run:
+```sh
+terraform init
+export GOOGLE_PROJECT="your-project-id"
+export GOOGLE_REGION="us-central1"
+terraform apply -var="datadog-api-key=$DD_API_KEY"
+```
+
+### Notes
+
+- `site` must match the Datadog site parameter of your account (see [this table](https://docs.datadoghq.com/getting_started/site/#access-the-datadog-site)).
+- `vpc_name` is the name prefix for the VPC resources where the Agentless scanner
+  is created. For security reasons, this VPC should be reserved for
+  the exclusive use of the scanner.
+- The scanner requires a service account with appropriate permissions to scan disks
+  in your GCP project. This module creates the necessary service accounts and IAM roles.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name                                                                      | Version |
+| ------------------------------------------------------------------------- | ------- |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0  |
+| <a name="requirement_google"></a> [google](#requirement\_google)          | ~> 6.0  |
+| <a name="requirement_random"></a> [random](#requirement\_random)          | ~> 3.0  |
+
+## Providers
+
+| Name                                                       | Version |
+| ---------------------------------------------------------- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0  |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0  |
+
+## Modules
+
+| Name                                                                                                                                                         | Source                                           | Version |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------ | ------- |
+| <a name="module_agentless_impersonated_service_account"></a> [agentless\_impersonated\_service\_account](#module\_agentless\_impersonated\_service\_account) | ./modules/agentless-impersonated-service-account | n/a     |
+| <a name="module_agentless_scanner_service_account"></a> [agentless\_scanner\_service\_account](#module\_agentless\_scanner\_service\_account)                | ./modules/agentless-scanner-service-account      | n/a     |
+| <a name="module_instance"></a> [instance](#module\_instance)                                                                                                 | ./modules/instance                               | n/a     |
+| <a name="module_vpc"></a> [vpc](#module\_vpc)                                                                                                                | ./modules/vpc                                    | n/a     |
+
+## Resources
+
+| Name                                                                                                                              | Type        |
+| --------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [random_id.deployment_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id)                  | resource    |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config)   | data source |
+| [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
+
+## Inputs
+
+| Name                                                                                       | Description                                                                                                   | Type           | Default                        | Required |
+| ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- | -------------- | ------------------------------ | :------: |
+| <a name="input_api_key"></a> [api\_key](#input\_api\_key)                                  | Datadog API key                                                                                               | `string`       | n/a                            |   yes    |
+| <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh)                         | Whether to enable SSH firewall rule                                                                           | `bool`         | `true`                         |    no    |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count)             | Number of instances in the managed instance group                                                             | `number`       | `1`                            |    no    |
+| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel)          | Specifies the channel to use for installing the scanner                                                       | `string`       | `"stable"`                     |    no    |
+| <a name="input_scanner_repository"></a> [scanner\_repository](#input\_scanner\_repository) | Repository URL to install the scanner from.                                                                   | `string`       | `"https://apt.datadoghq.com/"` |    no    |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version)          | Specifies the version of the scanner to install                                                               | `string`       | `"0.11"`                       |    no    |
+| <a name="input_site"></a> [site](#input\_site)                                             | Datadog site (for example, datadoghq.com, datadoghq.eu)                                                       | `string`       | `"datadoghq.com"`              |    no    |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key)           | SSH public key for instance access                                                                            | `string`       | `null`                         |    no    |
+| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username)                   | Username for SSH access                                                                                       | `string`       | `"ubuntu"`                     |    no    |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr)                      | The CIDR block for the subnet                                                                                 | `string`       | `"10.0.0.0/24"`                |    no    |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix)                | Unique suffix to append to resource names to avoid collisions. If not provided, a random suffix is generated. | `string`       | `""`                           |    no    |
+| <a name="input_vpc_name"></a> [vpc\_name](#input\_vpc\_name)                               | Name prefix for VPC resources                                                                                 | `string`       | `"datadog-agentless-scanner"`  |    no    |
+| <a name="input_zones"></a> [zones](#input\_zones)                                          | List of zones to deploy resources across. If empty, up to 3 zones in the region are automatically selected.   | `list(string)` | `[]`                           |    no    |
+
+## Outputs
+
+| Name                                                                                                                              | Description                               |
+| --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| <a name="output_health_check"></a> [health\_check](#output\_health\_check)                                                        | The health check for auto-healing         |
+| <a name="output_instance_group_manager"></a> [instance\_group\_manager](#output\_instance\_group\_manager)                        | The managed instance group manager        |
+| <a name="output_instance_template"></a> [instance\_template](#output\_instance\_template)                                         | The instance template used by the MIG     |
+| <a name="output_mig_target_size"></a> [mig\_target\_size](#output\_mig\_target\_size)                                             | Target size of the managed instance group |
+| <a name="output_scanner_service_account_email"></a> [scanner\_service\_account\_email](#output\_scanner\_service\_account\_email) | Email of the scanner service account      |
+| <a name="output_target_custom_role_name"></a> [target\_custom\_role\_name](#output\_target\_custom\_role\_name)                   | Name of the custom target role            |
+| <a name="output_target_service_account_email"></a> [target\_service\_account\_email](#output\_target\_service\_account\_email)    | Email of the target service account       |
+| <a name="output_unique_suffix"></a> [unique\_suffix](#output\_unique\_suffix)                                                     | Unique suffix used in resource names      |
+| <a name="output_vpc_network"></a> [vpc\_network](#output\_vpc\_network)                                                           | The VPC network created for the scanner   |
+| <a name="output_vpc_network_name"></a> [vpc\_network\_name](#output\_vpc\_network\_name)                                          | The name of the VPC network               |
+| <a name="output_vpc_subnet"></a> [vpc\_subnet](#output\_vpc\_subnet)                                                              | The subnet created for the scanner        |
+| <a name="output_vpc_subnet_name"></a> [vpc\_subnet\_name](#output\_vpc\_subnet\_name)                                             | The name of the VPC subnet                |
+| <a name="output_zones"></a> [zones](#output\_zones)                                                                               | Zones where instances are deployed        |
+<!-- END_TF_DOCS -->

--- a/gcp/modules/agentless-impersonated-service-account/README.md
+++ b/gcp/modules/agentless-impersonated-service-account/README.md
@@ -1,0 +1,69 @@
+# Agentless Impersonated Service Account Module
+
+This module creates a Google Cloud service account that can be impersonated by the Datadog Agentless Scanner to access and scan disk resources within your GCP project.
+
+## Overview
+
+The module creates:
+- A service account for disk scanning operations
+- Custom IAM roles with minimal required permissions for disk access
+- IAM bindings to allow the scanner service account to impersonate this target service account
+- Conditional access policies to limit scanner access to only its own created snapshots
+
+## Usage
+
+```hcl
+module "agentless_impersonated_service_account" {
+  source = "./modules/agentless-impersonated-service-account"
+
+  scanner_service_account_email = "scanner-sa@project.iam.gserviceaccount.com"
+  unique_suffix                 = "abc123"
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name                                                             | Version |
+| ---------------------------------------------------------------- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0  |
+
+## Providers
+
+| Name                                                       | Version |
+| ---------------------------------------------------------- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0  |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name                                                                                                                                                                 | Type        |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [google_project_iam_custom_role.snapshot_readonly_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role)      | resource    |
+| [google_project_iam_custom_role.target_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role)                 | resource    |
+| [google_project_iam_member.agentless_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)                | resource    |
+| [google_project_iam_member.agentless_use_snapshot_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)   | resource    |
+| [google_service_account.target_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account)                      | resource    |
+| [google_service_account_iam_member.impersonation_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource    |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config)                                      | data source |
+
+## Inputs
+
+| Name                                                                                                                            | Description                                                                 | Type     | Default | Required |
+| ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- | -------- | ------- | :------: |
+| <a name="input_scanner_service_account_email"></a> [scanner\_service\_account\_email](#input\_scanner\_service\_account\_email) | Email of the scanner service account that impersonates this service account | `string` | n/a     |   yes    |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix)                                                     | Unique suffix to append to resource names to avoid collisions               | `string` | `""`    |    no    |
+
+## Outputs
+
+| Name                                                                                                    | Description                                                                                      |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| <a name="output_custom_role"></a> [custom\_role](#output\_custom\_role)                                 | The custom role for reading disk information                                                     |
+| <a name="output_custom_role_name"></a> [custom\_role\_name](#output\_custom\_role\_name)                | Name of the custom target role                                                                   |
+| <a name="output_service_account"></a> [service\_account](#output\_service\_account)                     | The service account to be impersonated by Datadog Agentless Scanner for reading disk information |
+| <a name="output_service_account_email"></a> [service\_account\_email](#output\_service\_account\_email) | Email of the target service account                                                              |
+| <a name="output_service_account_name"></a> [service\_account\_name](#output\_service\_account\_name)    | Name of the target service account                                                               |
+<!-- END_TF_DOCS -->

--- a/gcp/modules/agentless-scanner-service-account/README.md
+++ b/gcp/modules/agentless-scanner-service-account/README.md
@@ -1,0 +1,69 @@
+# Agentless Scanner Service Account Module
+
+This module creates a Google Cloud service account for the Datadog Agentless Scanner instances with the necessary permissions to create, attach, and manage disks for scanning operations.
+
+## Overview
+
+The module creates:
+- A service account for scanner instances to use
+- Custom IAM roles with minimal required permissions for disk operations
+- IAM bindings to allow the service account to perform scanning operations
+- Access to Secret Manager for retrieving the Datadog API key
+- Conditional access policies to restrict operations to scanner-created resources
+
+## Usage
+
+```hcl
+module "agentless_scanner_service_account" {
+  source = "./modules/agentless-scanner-service-account"
+
+  api_key_secret_id = "datadog-api-key-secret"
+  unique_suffix     = "abc123"
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_project_iam_custom_role.attach_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_custom_role.zone_operations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.attach_disk_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.zone_operations_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_secret_manager_secret_iam_member.scanner_secret_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
+| [google_service_account.scanner_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account_iam_member.self_impersonation_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Name of the Secret Manager secret containing the Datadog API key | `string` | n/a | yes |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix to append to resource names to avoid collisions | `string` | `""` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_scanner_service_account"></a> [scanner\_service\_account](#output\_scanner\_service\_account) | The scanner service account |
+| <a name="output_scanner_service_account_email"></a> [scanner\_service\_account\_email](#output\_scanner\_service\_account\_email) | Email of the scanner service account |
+| <a name="output_scanner_service_account_name"></a> [scanner\_service\_account\_name](#output\_scanner\_service\_account\_name) | Name of the scanner service account |
+<!-- END_TF_DOCS -->

--- a/gcp/modules/instance/README.md
+++ b/gcp/modules/instance/README.md
@@ -1,0 +1,93 @@
+# Instance Module
+
+This module creates a Google Cloud Managed Instance Group (MIG) with Datadog Agentless Scanner instances. The MIG provides auto-scaling, auto-healing, and high availability across multiple zones.
+
+## Overview
+
+The module creates:
+- Instance template and startup script for scanner installation
+- Regional Managed Instance Group for high availability and auto-healing
+- Secret Manager secret for storing the Datadog API key (if not provided)
+- Proper distribution across multiple zones for fault tolerance
+
+## Usage
+
+```hcl
+module "instance" {
+  source = "./modules/instance"
+
+  zones                 = ["us-central1-a", "us-central1-b", "us-central1-c"]
+  network_name          = "datadog-agentless-scanner-vpc"
+  subnetwork_name       = "datadog-agentless-scanner-subnet"
+  service_account_email = "scanner-sa@project.iam.gserviceaccount.com"
+  
+  api_key            = var.datadog_api_key
+  site               = "datadoghq.com"
+  ssh_public_key     = var.ssh_public_key
+  ssh_username       = "ubuntu"
+  instance_count     = 3
+  scanner_version    = "0.11"
+  scanner_channel    = "stable"
+  scanner_repository = "https://apt.datadoghq.com/"
+  unique_suffix      = "abc123"
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name                                                             | Version |
+| ---------------------------------------------------------------- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0  |
+
+## Providers
+
+| Name                                                       | Version |
+| ---------------------------------------------------------- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0  |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name                                                                                                                                                                                       | Type        |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
+| [google_compute_health_check.agentless_scanner_health](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_health_check)                                | resource    |
+| [google_compute_instance_template.agentless_scanner_template](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template)                    | resource    |
+| [google_compute_region_instance_group_manager.agentless_scanner_mig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource    |
+| [google_secret_manager_secret.api_key_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret)                                        | resource    |
+| [google_secret_manager_secret_version.api_key_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version)                       | resource    |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config)                                                            | data source |
+
+## Inputs
+
+| Name                                                                                                  | Description                                                                            | Type           | Default | Required |
+| ----------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | -------------- | ------- | :------: |
+| <a name="input_api_key"></a> [api\_key](#input\_api\_key)                                             | Datadog API key                                                                        | `string`       | n/a     |   yes    |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name)                              | The name of the network                                                                | `string`       | n/a     |   yes    |
+| <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel)                     | Specifies the channel to use for installing the scanner                                | `string`       | n/a     |   yes    |
+| <a name="input_scanner_repository"></a> [scanner\_repository](#input\_scanner\_repository)            | Repository URL to install the scanner from.                                            | `string`       | n/a     |   yes    |
+| <a name="input_scanner_version"></a> [scanner\_version](#input\_scanner\_version)                     | Specifies the version of the scanner to install                                        | `string`       | n/a     |   yes    |
+| <a name="input_service_account_email"></a> [service\_account\_email](#input\_service\_account\_email) | Email of the service account to attach to instances                                    | `string`       | n/a     |   yes    |
+| <a name="input_site"></a> [site](#input\_site)                                                        | Datadog site (for example, datadoghq.com, datadoghq.eu)                                | `string`       | n/a     |   yes    |
+| <a name="input_ssh_username"></a> [ssh\_username](#input\_ssh\_username)                              | Username for SSH access                                                                | `string`       | n/a     |   yes    |
+| <a name="input_subnetwork_name"></a> [subnetwork\_name](#input\_subnetwork\_name)                     | The name of the subnetwork                                                             | `string`       | n/a     |   yes    |
+| <a name="input_zones"></a> [zones](#input\_zones)                                                     | List of zones to deploy resources across                                               | `list(string)` | n/a     |   yes    |
+| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id)           | Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key | `string`       | `null`  |    no    |
+| <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count)                        | Number of instances in the managed instance group                                      | `number`       | `1`     |    no    |
+| <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key)                      | SSH public key for instance access                                                     | `string`       | `null`  |    no    |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix)                           | Unique suffix to append to resource names to avoid collisions                          | `string`       | `""`    |    no    |
+
+## Outputs
+
+| Name                                                                                                       | Description                                                          |
+| ---------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| <a name="output_api_key_secret_id"></a> [api\_key\_secret\_id](#output\_api\_key\_secret\_id)              | The name of the Secret Manager secret containing the Datadog API key |
+| <a name="output_health_check"></a> [health\_check](#output\_health\_check)                                 | The health check for auto-healing                                    |
+| <a name="output_instance_group_manager"></a> [instance\_group\_manager](#output\_instance\_group\_manager) | The managed instance group manager                                   |
+| <a name="output_instance_template"></a> [instance\_template](#output\_instance\_template)                  | The instance template used by the MIG                                |
+| <a name="output_mig_target_size"></a> [mig\_target\_size](#output\_mig\_target\_size)                      | Target size of the managed instance group                            |
+| <a name="output_zones"></a> [zones](#output\_zones)                                                        | Zones where instances are distributed                                |
+<!-- END_TF_DOCS -->

--- a/gcp/modules/vpc/README.md
+++ b/gcp/modules/vpc/README.md
@@ -1,0 +1,77 @@
+# VPC Module
+
+This module creates a secure Virtual Private Cloud (VPC) network infrastructure for the Datadog Agentless Scanner on Google Cloud Platform. It provides isolated networking with private instances that have outbound internet access through a NAT gateway.
+
+## Overview
+
+The module creates:
+- VPC network with custom subnets (no default auto-created subnets)
+- Private subnet with Google Cloud API access enabled
+- Cloud Router and NAT Gateway for outbound internet connectivity
+- Firewall rules for health checks and optional SSH access via Identity-Aware Proxy
+- Proper security controls with minimal required access
+
+## Usage
+
+```hcl
+module "vpc" {
+  source = "./modules/vpc"
+
+  name          = "datadog-agentless-scanner"
+  subnet_cidr   = "10.0.0.0/24"
+  unique_suffix = "abc123"
+  enable_ssh    = true
+}
+```
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name                                                             | Version |
+| ---------------------------------------------------------------- | ------- |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0  |
+
+## Providers
+
+| Name                                                       | Version |
+| ---------------------------------------------------------- | ------- |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0  |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name                                                                                                                                           | Type        |
+| ---------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [google_compute_firewall.allow_health_checks](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall) | resource    |
+| [google_compute_firewall.allow_ssh](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_firewall)           | resource    |
+| [google_compute_network.vpc](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_network)                   | resource    |
+| [google_compute_router.router](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router)                  | resource    |
+| [google_compute_router_nat.nat](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_router_nat)             | resource    |
+| [google_compute_subnetwork.subnet](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork)          | resource    |
+| [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config)                | data source |
+
+## Inputs
+
+| Name                                                                        | Description                                                   | Type     | Default                       | Required |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------- | -------- | ----------------------------- | :------: |
+| <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh)          | Whether to enable SSH firewall rule                           | `bool`   | `true`                        |    no    |
+| <a name="input_name"></a> [name](#input\_name)                              | Name prefix for VPC resources                                 | `string` | `"datadog-agentless-scanner"` |    no    |
+| <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr)       | The CIDR block for the subnet                                 | `string` | `"10.0.0.0/24"`               |    no    |
+| <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix to append to resource names to avoid collisions | `string` | `""`                          |    no    |
+
+## Outputs
+
+| Name                                                                                | Description                                               |
+| ----------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| <a name="output_network_name"></a> [network\_name](#output\_network\_name)          | The name of the VPC network (for backward compatibility)  |
+| <a name="output_subnet"></a> [subnet](#output\_subnet)                              | The subnet created for the Datadog agentless scanner      |
+| <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id)                   | The ID of the subnet                                      |
+| <a name="output_subnet_name"></a> [subnet\_name](#output\_subnet\_name)             | The name of the subnet                                    |
+| <a name="output_subnetwork_name"></a> [subnetwork\_name](#output\_subnetwork\_name) | The name of the subnet (for backward compatibility)       |
+| <a name="output_vpc"></a> [vpc](#output\_vpc)                                       | The VPC network created for the Datadog agentless scanner |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id)                            | The ID of the VPC network                                 |
+| <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name)                      | The name of the VPC network                               |
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
Generate markdown documentation and TF docs for Agentless Scanning GCP modules. 