### PR TITLE
fix(gcp-service-account): fix incorrect account id issue when suffix is empty

### DIFF
--- a/gcp/modules/agentless-impersonated-service-account/main.tf
+++ b/gcp/modules/agentless-impersonated-service-account/main.tf
@@ -2,6 +2,8 @@ data "google_client_config" "current" {}
 
 locals {
   project_id = data.google_client_config.current.project
+  # Remove trailing hyphen when unique_suffix is empty
+  service_account_suffix = var.unique_suffix != "" ? "-${var.unique_suffix}" : ""
 }
 
 # Custom role for creating snapshots
@@ -25,7 +27,7 @@ resource "google_project_iam_custom_role" "create_snapshot" {
 }
 
 resource "google_service_account" "target_service_account" {
-  account_id   = "dd-agentless-target-${var.unique_suffix}"
+  account_id   = "dd-agentless-target${local.service_account_suffix}"
   display_name = "Datadog Agentless Target Service Account"
   description  = "Service account to be impersonated by Datadog Agentless Scanner for reading disk information"
 }

--- a/gcp/modules/agentless-scanner-service-account/main.tf
+++ b/gcp/modules/agentless-scanner-service-account/main.tf
@@ -2,11 +2,13 @@ data "google_client_config" "current" {}
 
 locals {
   project_id = data.google_client_config.current.project
+  # Remove trailing hyphen when unique_suffix is empty
+  service_account_suffix = var.unique_suffix != "" ? "-${var.unique_suffix}" : ""
 }
 
 # Service account for the scanner
 resource "google_service_account" "scanner_service_account" {
-  account_id   = "dd-agentless-scanner-${var.unique_suffix}"
+  account_id   = "dd-agentless-scanner${local.service_account_suffix}"
   display_name = "Scanner Service Account"
   description  = "Service account for the scanner"
 }


### PR DESCRIPTION
What?
=====
- remove trailing hyphen when `unique_suffix` is empty.

Why?
=====
- the default value of `unique_suffix` is "", meaning that by default the service account ids will be `dd-agentless-scanner-` and `dd-agentless-target-`, but a service account id ending with a hyphen is forbidden in GCP.