### PR TITLE
[K9VULN-8680] fix(gcp): homogenize variables inputs/outputs between all modules

### DIFF
--- a/gcp/README.md
+++ b/gcp/README.md
@@ -50,6 +50,7 @@ terraform apply -var="datadog-api-key=$DD_API_KEY"
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -57,6 +58,7 @@ terraform apply -var="datadog-api-key=$DD_API_KEY"
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -72,6 +74,7 @@ terraform apply -var="datadog-api-key=$DD_API_KEY"
 
 | Name | Type |
 |------|------|
+| [null_resource.api_key_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_id.deployment_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 | [google_compute_zones.available](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_zones) | data source |
@@ -80,7 +83,8 @@ terraform apply -var="datadog-api-key=$DD_API_KEY"
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key | `string` | n/a | yes |
+| <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key. Required when not using api\_key\_secret\_id. | `string` | `null` | no |
+| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key. Alternative to api\_key. | `string` | `null` | no |
 | <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh) | Whether to enable SSH firewall rule | `bool` | `true` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances in the managed instance group | `number` | `1` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Specifies the channel to use for installing the scanner | `string` | `"stable"` | no |

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -85,7 +85,7 @@ terraform apply -var="datadog-api-key=$DD_API_KEY"
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key. Required when not using api\_key\_secret\_id. | `string` | `null` | no |
 | <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key. Alternative to api\_key. | `string` | `null` | no |
-| <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh) | Whether to enable SSH firewall rule | `bool` | `true` | no |
+| <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh) | Whether to enable SSH firewall rule | `bool` | `false` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances in the managed instance group | `number` | `1` | no |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Specifies the channel to use for installing the scanner | `string` | `"stable"` | no |
 | <a name="input_scanner_repository"></a> [scanner\_repository](#input\_scanner\_repository) | Repository URL to install the scanner from. | `string` | `"https://apt.datadoghq.com/"` | no |

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -19,6 +19,8 @@ locals {
   region        = data.google_client_config.current.region
   project_id    = data.google_client_config.current.project
   zones         = length(var.zones) > 0 ? var.zones : slice(data.google_compute_zones.available.names, 0, min(3, length(data.google_compute_zones.available.names)))
+  # Validation to ensure exactly one of api_key or api_key_secret_id is provided
+  api_key_validation = (var.api_key != null && var.api_key_secret_id == null) || (var.api_key == null && var.api_key_secret_id != null)
 }
 
 # VPC Module - Creates network infrastructure for scanner instances
@@ -58,6 +60,7 @@ module "instance" {
   service_account_email = module.agentless_scanner_service_account.scanner_service_account_email
 
   api_key            = var.api_key
+  api_key_secret_id  = var.api_key_secret_id
   site               = var.site
   ssh_public_key     = var.ssh_public_key
   ssh_username       = var.ssh_username
@@ -68,4 +71,13 @@ module "instance" {
   unique_suffix      = local.unique_suffix
 
   depends_on = [module.vpc]
+}
+
+resource "null_resource" "api_key_validation" {
+  lifecycle {
+    precondition {
+      condition     = local.api_key_validation
+      error_message = "Exactly one of 'api_key' or 'api_key_secret_id' must be provided, but not both."
+    }
+  }
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -73,11 +73,13 @@ module "instance" {
   depends_on = [module.vpc]
 }
 
+# NOTE: Using count-based validation instead of preconditions because preconditions were
+# introduced in Terraform 1.2, which is too recent for our requirements.
+# See: https://github.com/hashicorp/terraform/blob/v1.2/CHANGELOG.md
 resource "null_resource" "api_key_validation" {
-  lifecycle {
-    precondition {
-      condition     = local.api_key_validation
-      error_message = "Exactly one of 'api_key' or 'api_key_secret_id' must be provided, but not both."
-    }
+  count = local.api_key_validation ? 0 : 1
+
+  triggers = {
+    error = "Exactly one of 'api_key' or 'api_key_secret_id' must be provided, but not both."
   }
 }

--- a/gcp/modules/agentless-scanner-service-account/README.md
+++ b/gcp/modules/agentless-scanner-service-account/README.md
@@ -60,7 +60,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the Secret Manager secret containing the Datadog API key | `string` | n/a | yes |
+| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the Secret Manager secret containing the Datadog API key in the format projects/[project\_id]/secrets/[secret\_name] | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix to append to resource names to avoid collisions. Must be alphanumeric only (no hyphens or underscores) and maximum 8 characters. If not provided, a random suffix is generated. | `string` | `""` | no |
 
 ## Outputs

--- a/gcp/modules/agentless-scanner-service-account/README.md
+++ b/gcp/modules/agentless-scanner-service-account/README.md
@@ -60,7 +60,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Name of the Secret Manager secret containing the Datadog API key | `string` | n/a | yes |
+| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the Secret Manager secret containing the Datadog API key | `string` | n/a | yes |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix to append to resource names to avoid collisions. Must be alphanumeric only (no hyphens or underscores) and maximum 8 characters. If not provided, a random suffix is generated. | `string` | `""` | no |
 
 ## Outputs

--- a/gcp/modules/agentless-scanner-service-account/main.tf
+++ b/gcp/modules/agentless-scanner-service-account/main.tf
@@ -11,7 +11,7 @@ locals {
   # Use provided unique_suffix or generate random one
   effective_suffix = var.unique_suffix != "" ? var.unique_suffix : random_id.deployment_suffix[0].hex
   # Extract secret name from full path (projects/PROJECT_ID/secrets/SECRET_NAME -> SECRET_NAME)
-  secret_name = regex("projects/[^/]+/secrets/(.+)$", var.api_key_secret_id)[0]
+  secret_name = regex("^projects/[a-zA-Z0-9-]+/secrets/([a-zA-Z0-9-]+)$", var.api_key_secret_id)[0]
 }
 
 # Service account for the scanner

--- a/gcp/modules/agentless-scanner-service-account/main.tf
+++ b/gcp/modules/agentless-scanner-service-account/main.tf
@@ -10,6 +10,8 @@ locals {
   project_id = data.google_client_config.current.project
   # Use provided unique_suffix or generate random one
   effective_suffix = var.unique_suffix != "" ? var.unique_suffix : random_id.deployment_suffix[0].hex
+  # Extract secret name from full path (projects/PROJECT_ID/secrets/SECRET_NAME -> SECRET_NAME)
+  secret_name = regex("projects/[^/]+/secrets/(.+)$", var.api_key_secret_id)[0]
 }
 
 # Service account for the scanner
@@ -72,7 +74,7 @@ resource "google_project_iam_member" "zone_operations_binding" {
 # Binding the secretmanager secret accessor role to the scanner service account
 resource "google_secret_manager_secret_iam_member" "scanner_secret_access" {
   project   = local.project_id
-  secret_id = var.api_key_secret_id
+  secret_id = local.secret_name
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.scanner_service_account.email}"
 }

--- a/gcp/modules/agentless-scanner-service-account/variables.tf
+++ b/gcp/modules/agentless-scanner-service-account/variables.tf
@@ -9,7 +9,7 @@ variable "unique_suffix" {
 }
 
 variable "api_key_secret_id" {
-  description = "Identifier of the Secret Manager secret containing the Datadog API key"
+  description = "Identifier of the Secret Manager secret containing the Datadog API key in the format projects/[project_id]/secrets/[secret_name]"
   type        = string
   validation {
     condition     = can(regex("^projects/[a-zA-Z0-9-]+/secrets/[a-zA-Z0-9-]+$", var.api_key_secret_id))

--- a/gcp/modules/agentless-scanner-service-account/variables.tf
+++ b/gcp/modules/agentless-scanner-service-account/variables.tf
@@ -9,6 +9,10 @@ variable "unique_suffix" {
 }
 
 variable "api_key_secret_id" {
-  description = "Name of the Secret Manager secret containing the Datadog API key"
+  description = "Identifier of the Secret Manager secret containing the Datadog API key"
   type        = string
+  validation {
+    condition     = can(regex("^projects/[a-zA-Z0-9-]+/secrets/[a-zA-Z0-9-]+$", var.api_key_secret_id))
+    error_message = "The ID must be in the format 'projects/[project_id]/secrets/[secret_name]'."
+  }
 }

--- a/gcp/modules/instance/README.md
+++ b/gcp/modules/instance/README.md
@@ -73,7 +73,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key. Either api\_key or api\_key\_secret\_id must be provided, but not both. | `string` | `null` | no |
-| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key | `string` | `null` | no |
+| <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the Secret Manager secret containing the Datadog API key in the format projects/[project\_id]/secrets/[secret\_name] | `string` | `null` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances in the managed instance group | `number` | `1` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the network | `string` | n/a | yes |
 | <a name="input_scanner_channel"></a> [scanner\_channel](#input\_scanner\_channel) | Specifies the channel to use for installing the scanner | `string` | n/a | yes |

--- a/gcp/modules/instance/README.md
+++ b/gcp/modules/instance/README.md
@@ -40,6 +40,7 @@ module "instance" {
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.0 |
+| <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 
 ## Providers
@@ -47,6 +48,7 @@ module "instance" {
 | Name | Version |
 |------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | ~> 6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 
 ## Modules
@@ -62,6 +64,7 @@ No modules.
 | [google_compute_region_instance_group_manager.agentless_scanner_mig](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_region_instance_group_manager) | resource |
 | [google_secret_manager_secret.api_key_secret](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret) | resource |
 | [google_secret_manager_secret_version.api_key_version](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_version) | resource |
+| [null_resource.api_key_validation](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [random_id.deployment_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 
@@ -69,7 +72,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key | `string` | n/a | yes |
+| <a name="input_api_key"></a> [api\_key](#input\_api\_key) | Datadog API key. Either api\_key or api\_key\_secret\_id must be provided, but not both. | `string` | `null` | no |
 | <a name="input_api_key_secret_id"></a> [api\_key\_secret\_id](#input\_api\_key\_secret\_id) | Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key | `string` | `null` | no |
 | <a name="input_instance_count"></a> [instance\_count](#input\_instance\_count) | Number of instances in the managed instance group | `number` | `1` | no |
 | <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the network | `string` | n/a | yes |

--- a/gcp/modules/instance/main.tf
+++ b/gcp/modules/instance/main.tf
@@ -131,11 +131,13 @@ resource "google_secret_manager_secret_version" "api_key_version" {
 }
 
 # Validation to ensure exactly one of api_key or api_key_secret_id is provided
+# NOTE: Using count-based validation instead of preconditions because preconditions were
+# introduced in Terraform 1.2, which is too recent for our requirements.
+# See: https://github.com/hashicorp/terraform/blob/v1.2/CHANGELOG.md
 resource "null_resource" "api_key_validation" {
-  lifecycle {
-    precondition {
-      condition     = local.api_key_validation
-      error_message = "Exactly one of 'api_key' or 'api_key_secret_id' must be provided, but not both."
-    }
+  count = local.api_key_validation ? 0 : 1
+
+  triggers = {
+    error = "Exactly one of 'api_key' or 'api_key_secret_id' must be provided, but not both."
   }
 }

--- a/gcp/modules/instance/main.tf
+++ b/gcp/modules/instance/main.tf
@@ -11,7 +11,7 @@ resource "random_id" "deployment_suffix" {
 locals {
   project_id        = data.google_client_config.current.project
   region            = data.google_client_config.current.region
-  api_key_secret_id = var.api_key_secret_id != null ? var.api_key_secret_id : google_secret_manager_secret.api_key_secret[0].name
+  api_key_secret_id = var.api_key_secret_id != null ? var.api_key_secret_id : google_secret_manager_secret.api_key_secret[0].id
   # Use provided unique_suffix or generate random one
   effective_suffix = var.unique_suffix != "" ? var.unique_suffix : random_id.deployment_suffix[0].hex
   # Validation for api_key XOR api_key_secret_id

--- a/gcp/modules/instance/provider.tf
+++ b/gcp/modules/instance/provider.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }

--- a/gcp/modules/instance/variables.tf
+++ b/gcp/modules/instance/variables.tf
@@ -19,8 +19,9 @@ variable "service_account_email" {
 }
 
 variable "api_key" {
-  description = "Datadog API key"
+  description = "Datadog API key. Either api_key or api_key_secret_id must be provided, but not both."
   type        = string
+  default     = null
   sensitive   = true
 }
 

--- a/gcp/modules/instance/variables.tf
+++ b/gcp/modules/instance/variables.tf
@@ -75,7 +75,7 @@ variable "scanner_repository" {
 }
 
 variable "api_key_secret_id" {
-  description = "Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key"
+  description = "Identifier of the Secret Manager secret containing the Datadog API key in the format projects/[project_id]/secrets/[secret_name]"
   type        = string
   default     = null
   validation {

--- a/gcp/modules/vpc/README.md
+++ b/gcp/modules/vpc/README.md
@@ -74,7 +74,6 @@ No modules.
 | <a name="output_subnet"></a> [subnet](#output\_subnet) | The subnet created for the Datadog agentless scanner |
 | <a name="output_subnet_id"></a> [subnet\_id](#output\_subnet\_id) | The ID of the subnet |
 | <a name="output_subnet_name"></a> [subnet\_name](#output\_subnet\_name) | The name of the subnet |
-| <a name="output_subnetwork_name"></a> [subnetwork\_name](#output\_subnetwork\_name) | The name of the subnet (for backward compatibility) |
 | <a name="output_vpc"></a> [vpc](#output\_vpc) | The VPC network created for the Datadog agentless scanner |
 | <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | The ID of the VPC network |
 | <a name="output_vpc_name"></a> [vpc\_name](#output\_vpc\_name) | The name of the VPC network |

--- a/gcp/modules/vpc/README.md
+++ b/gcp/modules/vpc/README.md
@@ -61,7 +61,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh) | Whether to enable SSH firewall rule | `bool` | `true` | no |
+| <a name="input_enable_ssh"></a> [enable\_ssh](#input\_enable\_ssh) | Whether to enable SSH firewall rule | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name prefix for VPC resources | `string` | `"datadog-agentless-scanner"` | no |
 | <a name="input_subnet_cidr"></a> [subnet\_cidr](#input\_subnet\_cidr) | The CIDR block for the subnet | `string` | `"10.0.0.0/24"` | no |
 | <a name="input_unique_suffix"></a> [unique\_suffix](#input\_unique\_suffix) | Unique suffix to append to resource names to avoid collisions. Must be alphanumeric only (no hyphens or underscores) and maximum 8 characters. If not provided, a random suffix is generated. | `string` | `""` | no |

--- a/gcp/modules/vpc/outputs.tf
+++ b/gcp/modules/vpc/outputs.tf
@@ -33,7 +33,3 @@ output "network_name" {
   value       = google_compute_network.vpc.name
 }
 
-output "subnetwork_name" {
-  description = "The name of the subnet (for backward compatibility)"
-  value       = google_compute_subnetwork.subnet.name
-}

--- a/gcp/modules/vpc/variables.tf
+++ b/gcp/modules/vpc/variables.tf
@@ -23,5 +23,5 @@ variable "subnet_cidr" {
 variable "enable_ssh" {
   description = "Whether to enable SSH firewall rule"
   type        = bool
-  default     = true
+  default     = false
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -48,7 +48,7 @@ output "vpc_subnet" {
 
 output "vpc_subnet_name" {
   description = "The name of the VPC subnet"
-  value       = module.vpc.subnetwork_name
+  value       = module.vpc.subnet_name
 }
 
 output "unique_suffix" {

--- a/gcp/provider.tf
+++ b/gcp/provider.tf
@@ -10,5 +10,9 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
   }
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -13,7 +13,7 @@ variable "subnet_cidr" {
 variable "enable_ssh" {
   description = "Whether to enable SSH firewall rule"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "api_key" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -17,8 +17,9 @@ variable "enable_ssh" {
 }
 
 variable "api_key" {
-  description = "Datadog API key"
+  description = "Datadog API key. Required when not using api_key_secret_id."
   type        = string
+  default     = null
   sensitive   = true
 }
 
@@ -80,6 +81,16 @@ variable "zones" {
   description = "List of zones to deploy resources across. If empty, up to 3 zones in the region are automatically selected."
   type        = list(string)
   default     = []
+}
+
+variable "api_key_secret_id" {
+  description = "Identifier of the pre-provisioned Secret Manager secret containing the Datadog API key. Alternative to api_key."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.api_key_secret_id == null || can(regex("^projects/[a-zA-Z0-9-]+/secrets/[a-zA-Z0-9-]+$", var.api_key_secret_id))
+    error_message = "The ID must be in the format 'projects/[project_id]/secrets/[secret_name]'."
+  }
 }
 
 variable "unique_suffix" {


### PR DESCRIPTION
What?
=====
- remove vpc module's duplicated output (`subnetwork_name`)
- make `api_key` variable optional and check that only one of (`api_key`, `api_key_secret_id `)
- homogenize `api_key_secret_id ` between all modules (long id instead of secret name)
- disable ssh access by default

Why?
=====
- for better homogeneity and clarity