### PR TITLE
[K9VULN-13195][k9-cloud-vm] - Add Azure Functions scanning permissions to delegate role

### DIFF
--- a/azure/arm/main.bicep
+++ b/azure/arm/main.bicep
@@ -319,6 +319,9 @@ resource delegateRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.Compute/disks/endGetAccess/action'
 
           'Microsoft.ContainerRegistry/registries/pull/read'
+
+          'Microsoft.Web/sites/read'
+          'Microsoft.Web/sites/functions/read'
         ]
         notActions: []
         dataActions: [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -422,7 +422,9 @@
               "Microsoft.Compute/disks/read",
               "Microsoft.Compute/disks/beginGetAccess/action",
               "Microsoft.Compute/disks/endGetAccess/action",
-              "Microsoft.ContainerRegistry/registries/pull/read"
+              "Microsoft.ContainerRegistry/registries/pull/read",
+              "Microsoft.Web/sites/read",
+              "Microsoft.Web/sites/functions/read"
             ],
             "notActions": [],
             "dataActions": [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.41.2.15936",
-      "templateHash": "15828281282769090906"
+      "templateHash": "6896456175162566816"
     }
   },
   "functions": [

--- a/azure/modules/roles/main.tf
+++ b/azure/modules/roles/main.tf
@@ -57,7 +57,10 @@ resource "azurerm_role_definition" "worker_role" {
       "Microsoft.Compute/disks/beginGetAccess/action",
       "Microsoft.Compute/disks/endGetAccess/action",
 
-      "Microsoft.ContainerRegistry/registries/pull/read"
+      "Microsoft.ContainerRegistry/registries/pull/read",
+
+      "Microsoft.Web/sites/read",
+      "Microsoft.Web/sites/functions/read"
     ]
     not_actions = []
     data_actions = [


### PR DESCRIPTION
## 🎯 Motivation

The agentless scanner needs RBAC permissions to discover and inspect Azure Function Apps for vulnerability scanning.

## 📎 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [JIRA](https://datadoghq.atlassian.net/browse/K9VULN-13195)


## 📋 Summary

Adds two Azure RBAC permissions to the worker (delegate) role across Terraform and ARM templates:

- `Microsoft.Web/sites/read` — allows listing and reading Function App resources
- `Microsoft.Web/sites/functions/read` — allows reading individual functions within a Function App

Files changed:
- `azure/modules/roles/main.tf` — Terraform worker role
- `azure/arm/main.bicep` — ARM Bicep delegate role
- `azure/arm/main.json` — Compiled ARM JSON template


## 🧪 Testing
- [ ] New tests were added for new logic.
- [ ] Existing tests were updated for new logic.
- [ ] Benchmark results prove that performance is the same or better.


## ✅ Staging validation
- [ ] Deployed and monitored using Datadog dashboards.
- [ ] Proof that it works as expected, including profiling or UX screenshots.

## 🔙 Recovery
Notes for on-call - **select only one**:
- [ ] The change can be rolled back.
- [ ] Do not roll back. Why?: