### PR TITLE
[K9VULN-13196][k9-cloud-vm] - Add GCP Cloud Run Functions scanning permissions to delegate role

### DIFF
--- a/gcp/modules/agentless-impersonated-service-account/main.tf
+++ b/gcp/modules/agentless-impersonated-service-account/main.tf
@@ -30,6 +30,15 @@ resource "google_project_iam_custom_role" "create_snapshot" {
     "compute.snapshots.setLabels",
 
     "compute.globalOperations.get",
+
+    "cloudfunctions.functions.list",
+    "cloudfunctions.functions.get",
+    "cloudfunctions.functions.sourceCodeGet",
+
+    "run.services.list",
+    "run.services.get",
+    "run.revisions.list",
+    "run.revisions.get",
   ]
 }
 


### PR DESCRIPTION
## 🎯 Motivation

Datadog Agentless Scanning currently scans Compute Engine disks on GCP. This change extends the target (impersonated) service account with the minimum IAM permissions needed for the scanner to also enumerate and scan **Cloud Functions (1st and 2nd gen)** and **Cloud Run services**, reaching parity with what the AWS side already supports for Lambda.

## 📎 Documentation

| **Document** | **Link or Detail** |
|---|---|
| RFC | N/A |
| Incident | N/A |
| Jira Ticket | [K9VULN-13196](https://datadoghq.atlassian.net/browse/K9VULN-13196) |

## 📋 Summary

After rolling this out, the agentless scanner can discover and scan Cloud Functions and Cloud Run workloads in the same project where the target service account is bound, using the existing impersonation flow. No new service account, no new binding — the permissions are added to the existing `datadogAgentlessTarget*` custom role so existing deployments pick them up on `terraform apply`.

The scan flow these permissions enable:
1. **List** functions and Cloud Run services in the project.
2. **Describe** each one to get metadata including source archive reference and container image URI.
3. **Download source archives** via `generateDownloadUrl`, which returns a short-lived signed GCS URL — no direct `storage.*` grant required.
4. **Pull container images** from Artifact Registry through the `roles/artifactregistry.reader` binding already present on this service account.

All seven new permissions are read-only. There is no write, create, update, or delete verb in the set.

### Per-permission justification

| Permission | Why it's needed |
|---|---|
| `cloudfunctions.functions.list` | Enumerate functions in the project — entry point for discovery. Covers both 1st-gen and 2nd-gen (the v1 and v2 APIs share the same IAM namespace). |
| `cloudfunctions.functions.get` | Read a function's metadata: runtime, entry point, source archive URL (1st gen) or `build_config.source.storage_source` and `build_config.docker_repository` (2nd gen). Direct analog of AWS `lambda:GetFunction`. |
| `cloudfunctions.functions.sourceCodeGet` | Required to call `projects.locations.functions.generateDownloadUrl`, which returns a short-lived signed URL to download the zipped source from the `gcf-sources-*` / `gcf-v2-sources-*` staging bucket. Using this flow avoids granting bulk `storage.objects.get` on the staging buckets — the signed URL carries its own credentials. Note: `roles/cloudfunctions.viewer` does **not** include this permission, which is why we don't use the predefined role. |
| `run.services.list` | Enumerate Cloud Run services in the project. Needed because 2nd-gen Cloud Functions are surfaced as Cloud Run services, and it also covers plain Cloud Run services. |
| `run.services.get` | Read service metadata including the pointer to the currently-ready revision. |
| `run.revisions.list` | List revisions attached to a service — needed to identify which revision's image to inspect. |
| `run.revisions.get` | Read the actual container image URI pinned to a revision (the service only references the revision; the image lives on the revision). This is what tells the scanner which image to pull from Artifact Registry. |

### What was deliberately **not** added

- `cloudfunctions.locations.list`, `cloudfunctions.operations.*` — tested as unnecessary for the scan path; omitted to keep the role minimal.
- `roles/run.viewer` — this predefined role covers what we need but also grants read on routes, configurations, executions, tasks, etc. The four granular `run.*` permissions above are the tested minimum.
- `storage.objects.get` on `gcf-*` buckets — unneeded because `generateDownloadUrl` returns self-signed URLs.
- `cloudbuild.*`, `eventarc.*`, `cloudkms.*` — these are consumed by the deploy/build path, not the read-only scan path.

No IAM condition is applied to the new permissions. Unlike AWS, GCP does not expose `cloudfunctions.*` or `run.*` as condition-enabled services, and labels on functions are not queryable from IAM conditions — so scoping has to happen at the project/folder binding level, which is how the scanner is already deployed.

## 🧪 Testing
- [ ] New tests were added for new logic.
- [ ] Existing tests were updated for new logic.
- [ ] Benchmark results prove that performance is the same or better.

No unit or integration tests added — this change is IAM configuration with no behavioral logic. Manually validated end-to-end on `dd-sbx-k9-agentless-2`: with only this permission set, the scanner successfully listed functions, fetched metadata, downloaded source archives via signed URL, and pulled container images from Artifact Registry. Permissions outside this set were tested and confirmed unnecessary for the scan path.

## ✅ Staging validation
- [X] Deployed and monitored using Datadog dashboards.
- [X] Proof that it works as expected, including profiling or UX screenshots.

## 🔙 Recovery
Notes for on-call - **select only one**:
- [X] The change can be rolled back.
- [ ] Do not roll back. Why?:

[K9VULN-13196]: https://datadoghq.atlassian.net/browse/K9VULN-13196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ