### PR TITLE
Always add the sensitive data scanning permissions to delegate IAM role

### DIFF
--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -73,7 +73,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerDelegateRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role and policies path | `string` | `"/"` | no |
-| <a name="input_scanner_organizational_unit_ids"></a> [scanner\_organizational\_unit\_ids](#input\_scanner\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) allowed to assume this role | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
+| <a name="input_scanner_organizational_unit_ids"></a> [scanner\_organizational\_unit\_ids](#input\_scanner\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) allowed to assume this role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | <a name="input_scanner_roles"></a> [scanner\_roles](#input\_scanner\_roles) | List of roles ARN allowed to assume this role | `list(string)` | n/a | yes |
 | <a name="input_sensitive_data_scanning_enabled"></a> [sensitive\_data\_scanning\_enabled](#input\_sensitive\_data\_scanning\_enabled) | Installs specific permissions to enable scanning of S3 buckets | `bool` | `true` | no |
 | <a name="input_sensitive_data_scanning_rds_enabled"></a> [sensitive\_data\_scanning\_rds\_enabled](#input\_sensitive\_data\_scanning\_rds\_enabled) | Installs specific permissions to enable scanning of RDS databases | `bool` | `false` | no |

--- a/modules/scanning-delegate-role/README.md
+++ b/modules/scanning-delegate-role/README.md
@@ -73,9 +73,9 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name to use on IAM role created | `string` | `"DatadogAgentlessScannerDelegateRole"` | no |
 | <a name="input_iam_role_path"></a> [iam\_role\_path](#input\_iam\_role\_path) | IAM role and policies path | `string` | `"/"` | no |
-| <a name="input_scanner_organizational_unit_ids"></a> [scanner\_organizational\_unit\_ids](#input\_scanner\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) allowed to assume this role | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="input_scanner_organizational_unit_ids"></a> [scanner\_organizational\_unit\_ids](#input\_scanner\_organizational\_unit\_ids) | List of AWS Organizations organizational units (OUs) allowed to assume this role | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_scanner_roles"></a> [scanner\_roles](#input\_scanner\_roles) | List of roles ARN allowed to assume this role | `list(string)` | n/a | yes |
-| <a name="input_sensitive_data_scanning_enabled"></a> [sensitive\_data\_scanning\_enabled](#input\_sensitive\_data\_scanning\_enabled) | Installs specific permissions to enable scanning of S3 buckets | `bool` | `false` | no |
+| <a name="input_sensitive_data_scanning_enabled"></a> [sensitive\_data\_scanning\_enabled](#input\_sensitive\_data\_scanning\_enabled) | Installs specific permissions to enable scanning of S3 buckets | `bool` | `true` | no |
 | <a name="input_sensitive_data_scanning_rds_enabled"></a> [sensitive\_data\_scanning\_rds\_enabled](#input\_sensitive\_data\_scanning\_rds\_enabled) | Installs specific permissions to enable scanning of RDS databases | `bool` | `false` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of additional tags to add to the IAM role/profile created | `map(string)` | `{}` | no |
 

--- a/modules/scanning-delegate-role/variables.tf
+++ b/modules/scanning-delegate-role/variables.tf
@@ -13,7 +13,7 @@ variable "iam_role_path" {
 variable "sensitive_data_scanning_enabled" {
   description = "Installs specific permissions to enable scanning of S3 buckets"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "sensitive_data_scanning_rds_enabled" {


### PR DESCRIPTION
## Summary
- Change the default value of `sensitive_data_scanning_enabled` from `false` to `true` in the scanning-delegate-role module
- The flag can still be explicitly set to `false` to opt out

## Motivation
Ease the setup experience for customers by adding the IAM permissions needed for sensitive data scanning automatically by default, removing the need to explicitly opt in. To enable the actual scanning features users still need to enable the AWS scan options. 

## Test plan
- [ ] Verify that new deployments get S3 scanning permissions by default
- [ ] Verify that setting `sensitive_data_scanning_enabled = false` still disables the permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)