### PR TITLE
fix(aws): ignore ASG desired_capacity drift

### DIFF
--- a/modules/instance/main.tf
+++ b/modules/instance/main.tf
@@ -114,6 +114,7 @@ resource "aws_autoscaling_group" "asg" {
   }
 
   lifecycle {
+    ignore_changes       = [desired_capacity]
     replace_triggered_by = [aws_security_group.default_scanner_security_group]
   }
 }


### PR DESCRIPTION
## What

Ignore changes to `desired_capacity` on the AWS scanner Auto Scaling Group.

## Why

The Agentless Scanner ASG scales up/down outside Terraform during normal operation. When this happens, Terraform sees `desired_capacity` drift (to 0) and repeatedly plans to reset it to `var.asg_size` (default 1), causing noisy/flapping plans.

Ignoring `desired_capacity` follows the HashiCorp pattern for Auto Scaling Groups.  See: https://developer.hashicorp.com/terraform/tutorials/aws/aws-asg#set-lifecycle-rule

## Testing

- Ran `terraform fmt -recursive`
- Ran `terraform validate`