### PR TITLE
feat(gcp): add storage.objectViewer role for GCR image pulls

### DIFF
--- a/gcp/modules/agentless-impersonated-service-account/README.md
+++ b/gcp/modules/agentless-impersonated-service-account/README.md
@@ -48,6 +48,7 @@ No modules.
 | [google_project_iam_custom_role.create_snapshot](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.snapshot_readonly_role](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_member.agentless_artifactregistry_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
+| [google_project_iam_member.agentless_gcr_storage_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.agentless_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.agentless_use_snapshot_role_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_service_account.target_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |

--- a/gcp/modules/agentless-impersonated-service-account/main.tf
+++ b/gcp/modules/agentless-impersonated-service-account/main.tf
@@ -62,6 +62,14 @@ resource "google_project_iam_member" "agentless_artifactregistry_role_binding" {
   member  = "serviceAccount:${google_service_account.target_service_account.email}"
 }
 
+# Binding the storage object viewer role for GCR (legacy Container Registry) image pulls.
+# GCR stores images in Cloud Storage, so pulling requires storage.objects.get + storage.objects.list.
+resource "google_project_iam_member" "agentless_gcr_storage_role_binding" {
+  project = local.project_id
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.target_service_account.email}"
+}
+
 # Binding the scanner service account to the impersonated service account
 resource "google_service_account_iam_member" "impersonation_binding" {
   service_account_id = google_service_account.target_service_account.name


### PR DESCRIPTION
## Summary
- Add `roles/storage.objectViewer` to the impersonated service account for GCR (legacy Container Registry) image pulls
- GCR stores images in Cloud Storage buckets, so the SA needs `storage.objects.get` and `storage.objects.list` permissions
- Part of the GCP container registry scanning initiative (Phase 1: Terraform Permissions)

## Context
This is Phase 1 of the GCP Container Registry Scanning plan. The existing `roles/artifactregistry.reader` covers Artifact Registry (`*.pkg.dev`), but GCR (`gcr.io` / `*.gcr.io`) requires Cloud Storage access.

## Test plan
- [ ] Deploy to `datadog-k9-agentless-2-sandbox` via `cloud-inventory` update
- [ ] Verify SA can pull images from `gcr.io` in sandbox project
- [ ] Verify existing Artifact Registry pulls still work (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)