### PR TITLE
feat(gcp): grant scanner SA token creator on itself for OCI private auth

### DIFF
--- a/gcp/modules/agentless-scanner-service-account/README.md
+++ b/gcp/modules/agentless-scanner-service-account/README.md
@@ -53,6 +53,7 @@ No modules.
 | [google_secret_manager_secret_iam_member.scanner_secret_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |
 | [google_service_account.scanner_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_service_account_iam_member.self_impersonation_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
+| [google_service_account_iam_member.self_token_creator_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_iam_member) | resource |
 | [random_id.deployment_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [google_client_config.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_config) | data source |
 

--- a/gcp/modules/agentless-scanner-service-account/main.tf
+++ b/gcp/modules/agentless-scanner-service-account/main.tf
@@ -84,3 +84,10 @@ resource "google_service_account_iam_member" "self_impersonation_binding" {
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.scanner_service_account.email}"
 }
+
+# Required by the OCI/GCR private-auth path, which mints OAuth2 tokens via impersonate.CredentialsTokenSource.
+resource "google_service_account_iam_member" "self_token_creator_binding" {
+  service_account_id = google_service_account.scanner_service_account.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  member             = "serviceAccount:${google_service_account.scanner_service_account.email}"
+}


### PR DESCRIPTION
## Summary
- The scanner SA currently self-binds only `roles/iam.serviceAccountUser`, which permits *attaching* the SA to a resource but **not** minting access tokens for it.
- The OCI/GCR private-auth code path in `datadog-agentless-scanner` calls `impersonate.CredentialsTokenSource` (via `pkg/gcpbackend/config.go`), which requires `roles/iam.serviceAccountTokenCreator`.
- Without this binding, scans against private Artifact Registry or GCR in the scanner's own project fail with `oci: access denied: could not find role for GCP project=...` after the role lookup, or with `iam.serviceaccounts.getAccessToken` 403s when the lookup is configured.

This adds a second self-binding for `roles/iam.serviceAccountTokenCreator`, leaving the existing `serviceAccountUser` binding untouched.

## Test plan
- [ ] `terraform plan` shows only the new `google_service_account_iam_member.self_token_creator_binding` resource being added.
- [ ] After apply, run the scanner against an image in a private Artifact Registry in the same project as the scanner: it should successfully pull the image via the OCI private-auth code path.
- [ ] Verified manually in `dd-sbx-k9-agentless-3` by adding the equivalent binding via gcloud; the OCI scan succeeded end to end against `us-east1-docker.pkg.dev/dd-sbx-k9-agentless-3/agentless-scanner-test/alpine@sha256:...`.

[K9VULN-15352
](https://datadoghq.atlassian.net/browse/K9VULN-15352) 🤖 Generated with [Claude Code](https://claude.com/claude-code)