### PR TITLE
[K9VULN-13195][k9-agentless-scanner] - azure: grant scanner read access to Function Apps

### DIFF
--- a/azure/arm/main.bicep
+++ b/azure/arm/main.bicep
@@ -323,7 +323,7 @@ resource delegateRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.ContainerRegistry/registries/pull/read'
 
           'Microsoft.Web/sites/read'
-          'Microsoft.Web/sites/basicPublishingCredentials/action'
+          'Microsoft.Web/sites/publish/Action'
         ]
         notActions: []
         dataActions: [

--- a/azure/arm/main.bicep
+++ b/azure/arm/main.bicep
@@ -321,6 +321,8 @@ resource delegateRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
         'Microsoft.Compute/galleries/images/versions/read'
 
           'Microsoft.ContainerRegistry/registries/pull/read'
+
+          'Microsoft.Web/sites/read'
         ]
         notActions: []
         dataActions: [

--- a/azure/arm/main.bicep
+++ b/azure/arm/main.bicep
@@ -323,6 +323,7 @@ resource delegateRole 'Microsoft.Authorization/roleDefinitions@2022-04-01' = {
           'Microsoft.ContainerRegistry/registries/pull/read'
 
           'Microsoft.Web/sites/read'
+          'Microsoft.Web/sites/basicPublishingCredentials/action'
         ]
         notActions: []
         dataActions: [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "15465662250401223487"
+      "templateHash": "15826653023760586094"
     }
   },
   "functions": [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "15826653023760586094"
+      "templateHash": "11377292179507260969"
     }
   },
   "functions": [
@@ -424,7 +424,8 @@
               "Microsoft.Compute/disks/endGetAccess/action",
               "Microsoft.Compute/galleries/images/versions/read",
               "Microsoft.ContainerRegistry/registries/pull/read",
-              "Microsoft.Web/sites/read"
+              "Microsoft.Web/sites/read",
+              "Microsoft.Web/sites/basicPublishingCredentials/action"
             ],
             "notActions": [],
             "dataActions": [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.43.8.12551",
-      "templateHash": "11377292179507260969"
+      "templateHash": "12092533371131685033"
     }
   },
   "functions": [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -425,7 +425,7 @@
               "Microsoft.Compute/galleries/images/versions/read",
               "Microsoft.ContainerRegistry/registries/pull/read",
               "Microsoft.Web/sites/read",
-              "Microsoft.Web/sites/basicPublishingCredentials/action"
+              "Microsoft.Web/sites/publish/Action"
             ],
             "notActions": [],
             "dataActions": [

--- a/azure/arm/main.json
+++ b/azure/arm/main.json
@@ -423,7 +423,8 @@
               "Microsoft.Compute/disks/beginGetAccess/action",
               "Microsoft.Compute/disks/endGetAccess/action",
               "Microsoft.Compute/galleries/images/versions/read",
-              "Microsoft.ContainerRegistry/registries/pull/read"
+              "Microsoft.ContainerRegistry/registries/pull/read",
+              "Microsoft.Web/sites/read"
             ],
             "notActions": [],
             "dataActions": [

--- a/azure/modules/roles/main.tf
+++ b/azure/modules/roles/main.tf
@@ -62,7 +62,7 @@ resource "azurerm_role_definition" "worker_role" {
       "Microsoft.ContainerRegistry/registries/pull/read",
 
       "Microsoft.Web/sites/read",
-      "Microsoft.Web/sites/basicPublishingCredentials/action"
+      "Microsoft.Web/sites/publish/Action"
     ]
     not_actions = []
     data_actions = [

--- a/azure/modules/roles/main.tf
+++ b/azure/modules/roles/main.tf
@@ -61,7 +61,8 @@ resource "azurerm_role_definition" "worker_role" {
 
       "Microsoft.ContainerRegistry/registries/pull/read",
 
-      "Microsoft.Web/sites/read"
+      "Microsoft.Web/sites/read",
+      "Microsoft.Web/sites/basicPublishingCredentials/action"
     ]
     not_actions = []
     data_actions = [

--- a/azure/modules/roles/main.tf
+++ b/azure/modules/roles/main.tf
@@ -59,7 +59,9 @@ resource "azurerm_role_definition" "worker_role" {
 
       "Microsoft.Compute/galleries/images/versions/read",
 
-      "Microsoft.ContainerRegistry/registries/pull/read"
+      "Microsoft.ContainerRegistry/registries/pull/read",
+
+      "Microsoft.Web/sites/read"
     ]
     not_actions = []
     data_actions = [


### PR DESCRIPTION
## 🎯 Motivation

Enable a new agentless-scanner feature that scans Azure Function Apps (container images). The scanner needs to read Function App properties to discover which apps are containerized and locate their backing images.

## 📎 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | [JIRA](https://datadoghq.atlassian.net/browse/K9VULN-13195)


## 📋 Summary

The Azure agentless scanner can now read Function App resources across every scanned subscription. Without this, the new Function App scanning workflow fails to list apps or determine their container image references.

ACR pull permissions are unchanged — the worker role already grants `Microsoft.ContainerRegistry/registries/pull/read` (plus the corresponding data action), which covers any ACR backing a Function App container.

The same permission is added in all three role-definition surfaces the module ships (Terraform module, ARM Bicep, ARM JSON) so users on any install path get the same capability.

## 🧪 Testing
- [ ] New tests were added for new logic.
- [ ] Existing tests were updated for new logic.
- [ ] Benchmark results prove that performance is the same or better.


## ✅ Staging validation
- [X] Deployed and monitored using Datadog dashboards.
- [X] Proof that it works as expected, including profiling or UX screenshots.

## 🔙 Recovery
Notes for on-call - **select only one**:
- [X] The change can be rolled back.
- [ ] Do not roll back. Why?: