### PR TITLE
Release 0.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Version 0.12.2 - 2026-06-01
+
+- GCP: grant the scanner service account token-creator on itself to support OCI private registry authentication
+- GCP: grant the target service account read access to Cloud Functions and Cloud Run
+- Azure: support identifiable app keys in the ARM template
+- Azure: add a unique name suffix to the virtual network
+- AWS: always include sensitive data scanning permissions in the delegate IAM role
+- Set standard Datadog tags in the Azure and GCP agent configuration
+- Allow the Datadog Agent to read the systemd journal
+
 ## Version 0.11.12 - 2025-11-10
 
 - Add initial GCP support with Terraform modules and examples (`single_region` and `cross_project`)

--- a/azure/README.md
+++ b/azure/README.md
@@ -74,7 +74,7 @@ To scan multiple subscriptions from a single scanner deployment:
 
 ```hcl
 module "datadog-agentless-scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//azure?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//azure?ref=0.12.2"
 
   # ... other configuration ...
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -74,7 +74,7 @@ To scan multiple subscriptions from a single scanner deployment:
 
 ```hcl
 module "datadog-agentless-scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//azure?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//azure?ref=0.12.2-rc.1"
 
   # ... other configuration ...
 

--- a/azure/modules/custom-data/templates/install.sh.tftpl
+++ b/azure/modules/custom-data/templates/install.sh.tftpl
@@ -133,7 +133,7 @@ api_key: $DD_API_KEY
 site: $DD_SITE
 azure_client_id: ${azure_client_id}
 installation_mode: terraform
-installation_version: 0.12.1
+installation_version: 0.12.2
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}

--- a/azure/modules/custom-data/templates/install.sh.tftpl
+++ b/azure/modules/custom-data/templates/install.sh.tftpl
@@ -133,7 +133,7 @@ api_key: $DD_API_KEY
 site: $DD_SITE
 azure_client_id: ${azure_client_id}
 installation_mode: terraform
-installation_version: 0.12.2
+installation_version: 0.12.2-rc.1
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}

--- a/examples/cross_account/other_account/main.tf
+++ b/examples/cross_account/other_account/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles = [var.scanner_role_arn]
 }

--- a/examples/cross_account/other_account/main.tf
+++ b/examples/cross_account/other_account/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles = [var.scanner_role_arn]
 }

--- a/examples/cross_account/scanner_account/main.tf
+++ b/examples/cross_account/scanner_account/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
 
   ## By default the scanner can assume any role with the default naming
   ## convention from any account.
@@ -40,13 +40,13 @@ module "scanner_role" {
 }
 
 module "self_delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   api_key               = var.datadog_api_key
   site                  = var.datadog_site
@@ -54,6 +54,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/cross_account/scanner_account/main.tf
+++ b/examples/cross_account/scanner_account/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2-rc.1"
 
   ## By default the scanner can assume any role with the default naming
   ## convention from any account.
@@ -40,13 +40,13 @@ module "scanner_role" {
 }
 
 module "self_delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   api_key               = var.datadog_api_key
   site                  = var.datadog_site
@@ -54,6 +54,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/custom_agent_configurations/main.tf
+++ b/examples/custom_agent_configurations/main.tf
@@ -14,19 +14,19 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
 
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   api_key               = var.api_key
   instance_profile_name = module.scanner_role.instance_profile.name
@@ -73,6 +73,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/custom_agent_configurations/main.tf
+++ b/examples/custom_agent_configurations/main.tf
@@ -14,19 +14,19 @@ provider "aws" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2-rc.1"
 
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   api_key               = var.api_key
   instance_profile_name = module.scanner_role.instance_profile.name
@@ -73,6 +73,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/custom_vpc/main.tf
+++ b/examples/custom_vpc/main.tf
@@ -14,25 +14,25 @@ provider "aws" {
 }
 
 module "user_data" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/user_data?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/user_data?ref=0.12.2-rc.1"
 
   api_key = var.api_key
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2-rc.1"
 
   api_key_secret_arns = [module.user_data.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles = [module.agentless_scanner_role.role.arn]
 }
 
 module "instance" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/instance?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/instance?ref=0.12.2-rc.1"
 
   user_data            = module.user_data.install_sh
   iam_instance_profile = module.agentless_scanner_role.instance_profile.name
@@ -41,6 +41,6 @@ module "instance" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/custom_vpc/main.tf
+++ b/examples/custom_vpc/main.tf
@@ -14,25 +14,25 @@ provider "aws" {
 }
 
 module "user_data" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/user_data?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/user_data?ref=0.12.2"
 
   api_key = var.api_key
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
 
   api_key_secret_arns = [module.user_data.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles = [module.agentless_scanner_role.role.arn]
 }
 
 module "instance" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/instance?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/instance?ref=0.12.2"
 
   user_data            = module.user_data.install_sh
   iam_instance_profile = module.agentless_scanner_role.instance_profile.name
@@ -41,6 +41,6 @@ module "instance" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2-rc.1"
 
   api_key_secret_arns = [
     module.agentless_scanner_us.api_key_secret_arn,
@@ -29,13 +29,13 @@ module "agentless_scanner_role" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles = [module.agentless_scanner_role.role.arn]
 }
 
 module "agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   providers = {
     aws = aws.us
@@ -46,7 +46,7 @@ module "agentless_scanner_us" {
 }
 
 module "agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   providers = {
     aws = aws.eu
@@ -57,6 +57,6 @@ module "agentless_scanner_eu" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/multi_region/main.tf
+++ b/examples/multi_region/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
 
   api_key_secret_arns = [
     module.agentless_scanner_us.api_key_secret_arn,
@@ -29,13 +29,13 @@ module "agentless_scanner_role" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles = [module.agentless_scanner_role.role.arn]
 }
 
 module "agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   providers = {
     aws = aws.us
@@ -46,7 +46,7 @@ module "agentless_scanner_us" {
 }
 
 module "agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   providers = {
     aws = aws.eu
@@ -57,6 +57,6 @@ module "agentless_scanner_eu" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/rds_scanning/main.tf
+++ b/examples/rds_scanning/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2-rc.1"
 
   account_roles = [module.delegate_role.role.arn]
   api_key_secret_arns = [
@@ -30,14 +30,14 @@ module "agentless_scanner_role" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles                       = [module.agentless_scanner_role.role.arn]
   sensitive_data_scanning_rds_enabled = true
 }
 
 module "agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   providers = {
     aws = aws.us
@@ -48,7 +48,7 @@ module "agentless_scanner_us" {
 }
 
 module "agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   providers = {
     aws = aws.eu
@@ -60,7 +60,7 @@ module "agentless_scanner_eu" {
 
 
 module "agentless_s3_bucket_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.2-rc.1"
 
   iam_delegate_role_arn = module.delegate_role.role.arn
   rds_service_role_arn  = module.delegate_role.rds_service_role_arn
@@ -71,7 +71,7 @@ module "agentless_s3_bucket_us" {
 }
 
 module "agentless_s3_bucket_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.2-rc.1"
 
   iam_delegate_role_arn = module.delegate_role.role.arn
   rds_service_role_arn  = module.delegate_role.rds_service_role_arn
@@ -82,6 +82,6 @@ module "agentless_s3_bucket_eu" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/rds_scanning/main.tf
+++ b/examples/rds_scanning/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "agentless_scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
 
   account_roles = [module.delegate_role.role.arn]
   api_key_secret_arns = [
@@ -30,14 +30,14 @@ module "agentless_scanner_role" {
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles                       = [module.agentless_scanner_role.role.arn]
   sensitive_data_scanning_rds_enabled = true
 }
 
 module "agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   providers = {
     aws = aws.us
@@ -48,7 +48,7 @@ module "agentless_scanner_us" {
 }
 
 module "agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   providers = {
     aws = aws.eu
@@ -60,7 +60,7 @@ module "agentless_scanner_eu" {
 
 
 module "agentless_s3_bucket_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.2"
 
   iam_delegate_role_arn = module.delegate_role.role.arn
   rds_service_role_arn  = module.delegate_role.rds_service_role_arn
@@ -71,7 +71,7 @@ module "agentless_s3_bucket_us" {
 }
 
 module "agentless_s3_bucket_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-s3-bucket?ref=0.12.2"
 
   iam_delegate_role_arn = module.delegate_role.role.arn
   rds_service_role_arn  = module.delegate_role.rds_service_role_arn
@@ -82,6 +82,6 @@ module "agentless_s3_bucket_eu" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/single_region/main.tf
+++ b/examples/single_region/main.tf
@@ -34,19 +34,19 @@ resource "datadog_agentless_scanning_aws_scan_options" "scan_options" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
 
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
 
   api_key               = var.datadog_api_key
   site                  = var.datadog_site
@@ -54,6 +54,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/examples/single_region/main.tf
+++ b/examples/single_region/main.tf
@@ -34,19 +34,19 @@ resource "datadog_agentless_scanning_aws_scan_options" "scan_options" {
 }
 
 module "scanner_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanner-role?ref=0.12.2-rc.1"
 
   api_key_secret_arns = [module.agentless_scanner.api_key_secret_arn]
 }
 
 module "delegate_role" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/scanning-delegate-role?ref=0.12.2-rc.1"
 
   scanner_roles = [module.scanner_role.role.arn]
 }
 
 module "agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner?ref=0.12.2-rc.1"
 
   api_key               = var.datadog_api_key
   site                  = var.datadog_site
@@ -54,6 +54,6 @@ module "agentless_scanner" {
 }
 
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }

--- a/gcp/examples/multi_project_multi_region/other_project/main.tf
+++ b/gcp/examples/multi_project_multi_region/other_project/main.tf
@@ -33,7 +33,7 @@ resource "datadog_agentless_scanning_gcp_scan_options" "scanned_project" {
 # Create an impersonated service account for the shared scanner service account
 # This allows the scanner (deployed in multiple regions) to scan resources in this project
 module "agentless_impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = var.scanner_service_account_email
 }

--- a/gcp/examples/multi_project_multi_region/other_project/main.tf
+++ b/gcp/examples/multi_project_multi_region/other_project/main.tf
@@ -33,7 +33,7 @@ resource "datadog_agentless_scanning_gcp_scan_options" "scanned_project" {
 # Create an impersonated service account for the shared scanner service account
 # This allows the scanner (deployed in multiple regions) to scan resources in this project
 module "agentless_impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = var.scanner_service_account_email
 }

--- a/gcp/examples/multi_project_multi_region/scanner_project/main.tf
+++ b/gcp/examples/multi_project_multi_region/scanner_project/main.tf
@@ -60,7 +60,7 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 # The scanner service account is the identity used by scanner VMs to run scans
 # and report results to Datadog.
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
@@ -68,7 +68,7 @@ module "scanner_service_account" {
 # The impersonated service account grants the scanner cross-project access
 # to scan resources in this project.
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -77,7 +77,7 @@ module "impersonated_service_account" {
 
 # Deploy the scanner infrastructure in US region
 module "datadog_agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   providers = {
     google = google.us
@@ -91,7 +91,7 @@ module "datadog_agentless_scanner_us" {
 
 # Deploy the scanner infrastructure in EU region
 module "datadog_agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   providers = {
     google = google.eu

--- a/gcp/examples/multi_project_multi_region/scanner_project/main.tf
+++ b/gcp/examples/multi_project_multi_region/scanner_project/main.tf
@@ -60,7 +60,7 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 # The scanner service account is the identity used by scanner VMs to run scans
 # and report results to Datadog.
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2-rc.1"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
@@ -68,7 +68,7 @@ module "scanner_service_account" {
 # The impersonated service account grants the scanner cross-project access
 # to scan resources in this project.
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -77,7 +77,7 @@ module "impersonated_service_account" {
 
 # Deploy the scanner infrastructure in US region
 module "datadog_agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   providers = {
     google = google.us
@@ -91,7 +91,7 @@ module "datadog_agentless_scanner_us" {
 
 # Deploy the scanner infrastructure in EU region
 module "datadog_agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   providers = {
     google = google.eu

--- a/gcp/examples/multi_project_single_region/other_project/main.tf
+++ b/gcp/examples/multi_project_single_region/other_project/main.tf
@@ -33,7 +33,7 @@ resource "datadog_agentless_scanning_gcp_scan_options" "scanned_project" {
 # Create an impersonated service account for the scanner service account
 # This allows the scanner to scan resources in this project
 module "agentless_impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = var.scanner_service_account_email
 }

--- a/gcp/examples/multi_project_single_region/other_project/main.tf
+++ b/gcp/examples/multi_project_single_region/other_project/main.tf
@@ -33,7 +33,7 @@ resource "datadog_agentless_scanning_gcp_scan_options" "scanned_project" {
 # Create an impersonated service account for the scanner service account
 # This allows the scanner to scan resources in this project
 module "agentless_impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = var.scanner_service_account_email
 }

--- a/gcp/examples/multi_project_single_region/scanner_project/main.tf
+++ b/gcp/examples/multi_project_single_region/scanner_project/main.tf
@@ -48,7 +48,7 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 # The scanner service account is the identity used by scanner VMs to run scans
 # and report results to Datadog.
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2-rc.1"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
@@ -56,7 +56,7 @@ module "scanner_service_account" {
 # The impersonated service account grants the scanner cross-project access
 # to scan resources in this project.
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -65,7 +65,7 @@ module "impersonated_service_account" {
 
 # Deploy the scanner infrastructure in a single region
 module "datadog_agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
   api_key_secret_id             = google_secret_manager_secret.dd_api_key.id

--- a/gcp/examples/multi_project_single_region/scanner_project/main.tf
+++ b/gcp/examples/multi_project_single_region/scanner_project/main.tf
@@ -48,7 +48,7 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 # The scanner service account is the identity used by scanner VMs to run scans
 # and report results to Datadog.
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
@@ -56,7 +56,7 @@ module "scanner_service_account" {
 # The impersonated service account grants the scanner cross-project access
 # to scan resources in this project.
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -65,7 +65,7 @@ module "impersonated_service_account" {
 
 # Deploy the scanner infrastructure in a single region
 module "datadog_agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
   api_key_secret_id             = google_secret_manager_secret.dd_api_key.id

--- a/gcp/examples/single_project_multi_region/main.tf
+++ b/gcp/examples/single_project_multi_region/main.tf
@@ -59,7 +59,7 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 # The scanner service account is the identity used by scanner VMs to run scans
 # and report results to Datadog.
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2-rc.1"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
@@ -67,7 +67,7 @@ module "scanner_service_account" {
 # The impersonated service account grants the scanner cross-project access
 # to scan resources in this project.
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -75,7 +75,7 @@ module "impersonated_service_account" {
 # ── Regional infrastructure (per region, symmetric) ──
 
 module "datadog_agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   providers = {
     google = google.us
@@ -88,7 +88,7 @@ module "datadog_agentless_scanner_us" {
 }
 
 module "datadog_agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   providers = {
     google = google.eu

--- a/gcp/examples/single_project_multi_region/main.tf
+++ b/gcp/examples/single_project_multi_region/main.tf
@@ -59,7 +59,7 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 # The scanner service account is the identity used by scanner VMs to run scans
 # and report results to Datadog.
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
@@ -67,7 +67,7 @@ module "scanner_service_account" {
 # The impersonated service account grants the scanner cross-project access
 # to scan resources in this project.
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -75,7 +75,7 @@ module "impersonated_service_account" {
 # ── Regional infrastructure (per region, symmetric) ──
 
 module "datadog_agentless_scanner_us" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   providers = {
     google = google.us
@@ -88,7 +88,7 @@ module "datadog_agentless_scanner_us" {
 }
 
 module "datadog_agentless_scanner_eu" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   providers = {
     google = google.eu

--- a/gcp/examples/single_project_single_region/README.md
+++ b/gcp/examples/single_project_single_region/README.md
@@ -87,19 +87,19 @@ To reference a **pre-existing** Secret Manager secret instead, remove the `googl
 
 ```hcl
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
 
   api_key_secret_id = "projects/YOUR_PROJECT/secrets/YOUR_SECRET_NAME"
 }
 
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
 
 module "datadog_agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
   api_key_secret_id             = "projects/YOUR_PROJECT/secrets/YOUR_SECRET_NAME"

--- a/gcp/examples/single_project_single_region/README.md
+++ b/gcp/examples/single_project_single_region/README.md
@@ -87,19 +87,19 @@ To reference a **pre-existing** Secret Manager secret instead, remove the `googl
 
 ```hcl
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2-rc.1"
 
   api_key_secret_id = "projects/YOUR_PROJECT/secrets/YOUR_SECRET_NAME"
 }
 
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
 
 module "datadog_agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
   api_key_secret_id             = "projects/YOUR_PROJECT/secrets/YOUR_SECRET_NAME"

--- a/gcp/examples/single_project_single_region/main.tf
+++ b/gcp/examples/single_project_single_region/main.tf
@@ -45,13 +45,13 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 }
 
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
 
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -59,7 +59,7 @@ module "impersonated_service_account" {
 # ── Scanner infrastructure ──
 
 module "datadog_agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.1"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
   api_key_secret_id             = google_secret_manager_secret.dd_api_key.id

--- a/gcp/examples/single_project_single_region/main.tf
+++ b/gcp/examples/single_project_single_region/main.tf
@@ -45,13 +45,13 @@ resource "google_secret_manager_secret_version" "dd_api_key" {
 }
 
 module "scanner_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-scanner-service-account?ref=0.12.2-rc.1"
 
   api_key_secret_id = google_secret_manager_secret.dd_api_key.id
 }
 
 module "impersonated_service_account" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp/modules/agentless-impersonated-service-account?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
 }
@@ -59,7 +59,7 @@ module "impersonated_service_account" {
 # ── Scanner infrastructure ──
 
 module "datadog_agentless_scanner" {
-  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2"
+  source = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//gcp?ref=0.12.2-rc.1"
 
   scanner_service_account_email = module.scanner_service_account.scanner_service_account_email
   api_key_secret_id             = google_secret_manager_secret.dd_api_key.id

--- a/gcp/modules/instance/startup-script.sh.tftpl
+++ b/gcp/modules/instance/startup-script.sh.tftpl
@@ -100,7 +100,7 @@ hostname: $DD_HOSTNAME
 api_key: $DD_API_KEY
 site: $DD_SITE
 installation_mode: terraform
-installation_version: 0.12.1
+installation_version: 0.12.2
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}

--- a/gcp/modules/instance/startup-script.sh.tftpl
+++ b/gcp/modules/instance/startup-script.sh.tftpl
@@ -100,7 +100,7 @@ hostname: $DD_HOSTNAME
 api_key: $DD_API_KEY
 site: $DD_SITE
 installation_mode: terraform
-installation_version: 0.12.2
+installation_version: 0.12.2-rc.1
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}

--- a/modules/agentless-scanners-autoscaling/README.md
+++ b/modules/agentless-scanners-autoscaling/README.md
@@ -6,7 +6,7 @@ Add the module to your Terraform configuration and provide the name of the Datad
 
 ```hcl
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2-rc.1"
   datadog_integration_role = var.datadog_integration_role
 }
 ```

--- a/modules/agentless-scanners-autoscaling/README.md
+++ b/modules/agentless-scanners-autoscaling/README.md
@@ -6,7 +6,7 @@ Add the module to your Terraform configuration and provide the name of the Datad
 
 ```hcl
 module "autoscaling_scanners" {
-  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.1"
+  source                   = "git::https://github.com/DataDog/terraform-module-datadog-agentless-scanner//modules/agentless-scanners-autoscaling?ref=0.12.2"
   datadog_integration_role = var.datadog_integration_role
 }
 ```

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -129,7 +129,7 @@ hostname: $DD_HOSTNAME
 api_key: $DD_API_KEY
 site: $DD_SITE
 installation_mode: terraform
-installation_version: 0.12.2
+installation_version: 0.12.2-rc.1
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}

--- a/modules/user_data/templates/install.sh.tftpl
+++ b/modules/user_data/templates/install.sh.tftpl
@@ -129,7 +129,7 @@ hostname: $DD_HOSTNAME
 api_key: $DD_API_KEY
 site: $DD_SITE
 installation_mode: terraform
-installation_version: 0.12.1
+installation_version: 0.12.2
 %{if length(scanner_configuration) > 0}
 ${yamlencode(scanner_configuration)}
 %{endif}


### PR DESCRIPTION
## 🎯 Motivation

Cut the `0.12.2` release of the Terraform module. All changes since `0.12.1` (GCP/Azure/AWS permission and config additions) are merged on `main`; this PR prepares the repo so the new version can be tagged.

## 📎 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A

## 📋 Summary

Prepares the `0.12.2` release. Every example and README now pins the module source at `?ref=0.12.2`, and the AWS/Azure/GCP agent install templates report `installation_version: 0.12.2`, so anyone copying an example deploys the new version instead of `0.12.1`. The CHANGELOG documents what shipped in `0.12.2`: GCP token-creator self-impersonation for OCI private registries, GCP target access to Cloud Functions and Cloud Run, Azure identifiable app keys, a unique Azure VNet name suffix, sensitive-data-scanning permissions always present on the AWS delegate role, standard Datadog tags in the Azure/GCP agent config, and systemd journal read access for the Agent.

Once merged, the `0.12.2` tag and GitHub Release are created from the merge commit (separate, no-PR step).

## 🧪 Testing
- [ ] New tests were added for new logic.
- [ ] Existing tests were updated for new logic.
- [ ] Benchmark results prove that performance is the same or better.

Version-pin and documentation change only — no logic changed. `terraform validate` runs in CI for the affected providers.

## ✅ Staging validation
- [X] Deployed and monitored using Datadog dashboards.
- [X] Proof that it works as expected, including profiling or UX screenshots.

## 🔙 Recovery
Notes for on-call - **select only one**:
- [X] The change can be rolled back.
- [ ] Do not roll back. Why?: