### PR TITLE
Release 0.12.2-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version 0.12.2-rc.1 - 2026-06-01
+## Version 0.12.2 - 2026-06-01
 
 - GCP: grant the scanner service account token-creator on itself to support OCI private registry authentication
 - GCP: grant the target service account read access to Cloud Functions and Cloud Run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Version 0.12.2-rc.1 - 2026-06-01
+
+- GCP: grant the scanner service account token-creator on itself to support OCI private registry authentication
+- GCP: grant the target service account read access to Cloud Functions and Cloud Run
+- Azure: support identifiable app keys in the ARM template
+- Azure: add a unique name suffix to the virtual network
+- AWS: always include sensitive data scanning permissions in the delegate IAM role
+- Set standard Datadog tags in the Azure and GCP agent configuration
+- Allow the Datadog Agent to read the systemd journal
+
 ## Version 0.11.12 - 2025-11-10
 
 - Add initial GCP support with Terraform modules and examples (`single_region` and `cross_project`)


### PR DESCRIPTION
## 🎯 Motivation

Cut the `0.12.2-rc.1` release candidate of the Terraform module.

## 📎 Documentation
**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A

## 📋 Summary

Adds the CHANGELOG entry for `0.12.2-rc.1`. Documents all changes since `0.12.1`: GCP token-creator self-impersonation for OCI private registries, GCP target access to Cloud Functions and Cloud Run, Azure identifiable app keys, a unique Azure VNet name suffix, sensitive-data-scanning permissions always present on the AWS delegate role, standard Datadog tags in the Azure/GCP agent config, and systemd journal read access for the Agent.