### PR TITLE
feat(gcp): grant scanner SA artifactregistry.reader for Cloud Functions image pulls

### DIFF
--- a/gcp/modules/agentless-scanner-service-account/README.md
+++ b/gcp/modules/agentless-scanner-service-account/README.md
@@ -48,6 +48,7 @@ No modules.
 |------|------|
 | [google_project_iam_custom_role.attach_disk](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
 | [google_project_iam_custom_role.zone_operations](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_custom_role) | resource |
+| [google_project_iam_member.artifactregistry_reader_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.attach_disk_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_project_iam_member.zone_operations_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member) | resource |
 | [google_secret_manager_secret_iam_member.scanner_secret_access](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/secret_manager_secret_iam_member) | resource |

--- a/gcp/modules/agentless-scanner-service-account/main.tf
+++ b/gcp/modules/agentless-scanner-service-account/main.tf
@@ -91,3 +91,14 @@ resource "google_service_account_iam_member" "self_token_creator_binding" {
   role               = "roles/iam.serviceAccountTokenCreator"
   member             = "serviceAccount:${google_service_account.scanner_service_account.email}"
 }
+
+# The scanner pulls Cloud Functions / Cloud Run container images directly from
+# Artifact Registry, authenticating as itself through the OCI private-auth path
+# (see self_token_creator_binding above). The artifactregistry.reader role on the
+# impersonated target SA does not apply to these pulls because they are performed
+# as the scanner SA, so the scanner SA needs to read Artifact Registry directly.
+resource "google_project_iam_member" "artifactregistry_reader_binding" {
+  project = local.project_id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.scanner_service_account.email}"
+}


### PR DESCRIPTION
## 🎯 Motivation

GCP agentless GCF/Cloud Run scanning is failing in staging when pulling container images:

```
GET .../dd-plt-k9-agentless/gcf-artifacts/.../manifests/version_1:
DENIED: Permission 'artifactregistry.repositories.downloadArtifacts' denied on resource (or it may not exist).
```

Gen2 Cloud Functions store their images in Artifact Registry (`*-docker.pkg.dev/.../gcf-artifacts`). The scanner authenticates to the registry **as the scanner SA** via the OCI private-auth path introduced in #281 (self `serviceAccountTokenCreator`, which mints an OAuth2 token via `impersonate.CredentialsTokenSource`). Audit logs confirm the scanner calling `iam.serviceAccounts.actAs` on itself.

But `roles/artifactregistry.reader` is only granted to the **impersonated target SA** (`agentless-impersonated-service-account`), not the scanner SA. Discovery works (the delegate role carries `cloudfunctions.*`/`run.*`), but the image pull is denied because the identity performing it has no Artifact Registry access.

## 📋 Summary

Grant `roles/artifactregistry.reader` to the **scanner SA** in `agentless-scanner-service-account`, mirroring the existing grant on the target SA. This lets the scanner pull Cloud Functions / Cloud Run images under the identity that actually performs the pull (the OCI private-auth path).

Note: `roles/storage.objectViewer` for legacy GCR pulls (added in #280) is likewise only on the target SA. If GCR-backed images are pulled via the same OCI private-auth path, that grant has the same gap and would need the same treatment — left out of scope here since the failing path is Artifact Registry.

## 🧪 Testing

- `terraform fmt` and `terraform validate` pass for the module.
- README resource table regenerated (terraform-docs).
- Verified against live IAM in `dd-plt-k9-agentless`: scanner SA `dd-agentless-scanner-k9stag` has no Artifact Registry permission; target SA `dd-agentless-target-k9stag` has `artifactregistry.reader`. This change closes that gap on the scanner SA.

## 📎 Documentation

**Document** | **Link or Detail**
-------------|------------------
RFC | N/A
Incident | N/A
Jira Ticket | N/A
